### PR TITLE
Ensure specification is passed into dataset package

### DIFF
--- a/digital_land/api.py
+++ b/digital_land/api.py
@@ -203,7 +203,7 @@ class DigitalLandApi(object):
         if not output_path:
             print("missing output path")
             sys.exit(2)
-        package = DatasetPackage(self.dataset)
+        package = DatasetPackage(self.dataset, specification=self.specification)
         package.create()
         for path in input_paths:
             package.load_transformed(path)


### PR DESCRIPTION
If not, DatasetPackage will try and regenerate specification, but it will do with paths relative to the current working directory, which are not present