### PR TITLE
Don't split references with a space after the colon

### DIFF
--- a/digital_land/phase/reference.py
+++ b/digital_land/phase/reference.py
@@ -1,11 +1,17 @@
+import re
 from .phase import Phase
 
 
+# match CURIEs which don't have a space after the colon
+curie_re = re.compile(r"(?P<prefix>[A-Za-z0-9_-]+):(?P<reference>[A-Za-z0-9_-].*)$")
+
+
 def split_curie(value):
-    s = value.split(":", 2)
-    if len(s) == 2:
-        return s
-    return ["", value]
+    match = curie_re.match(value)
+    if not match:
+        return ["", value]
+
+    return [match.group("prefix"), match.group("reference")]
 
 
 class EntityReferencePhase(Phase):

--- a/tests/unit/test_reference.py
+++ b/tests/unit/test_reference.py
@@ -2,6 +2,14 @@
 
 from digital_land.specification import Specification
 from digital_land.phase.reference import EntityReferencePhase, FactReferencePhase
+from digital_land.phase.reference import split_curie
+
+
+def test_split_curie():
+    assert ["", "value"] == split_curie("value")
+    assert ["wikidata", "Q1234"] == split_curie("wikidata:Q1234")
+    assert ["", "NSP22: A Street"] == split_curie("NSP22: A Street")
+    assert ["", "Not A CURIE:"] == split_curie("Not A CURIE:")
 
 
 def test_entity_reference():
@@ -13,6 +21,10 @@ def test_entity_reference():
         {"prefix": "foo", "reference": "Q1234"}
     )
     assert ("wikidata", "Q1234") == phase.process_row({"reference": "wikidata:Q1234"})
+    assert ("tree", "NSP22: Not A CURIE") == phase.process_row(
+        {"reference": "NSP22: Not A CURIE"}
+    )
+    assert ("tree", "Not A CURIE:") == phase.process_row({"reference": "Not A CURIE:"})
     assert ("foo", "Q1234") == phase.process_row(
         {"prefix": "foo", "reference": "wikidata:Q1234"}
     )


### PR DESCRIPTION
We're using Article 4 Direction names as references for some of our pilot local authorities. Some of these names contain colons, so are being parsed as CURIE references.

For now we can work around this issue by only splitting references into a prefix and a reference where they have a prefix which is an XML NCNAME and a colon which is not followed by a space:

https://regex101.com/r/M8vMfs/1