### PR TITLE
Version locking shapely to 1.8.0 to mitigate listed-buildings-collection pipeline execution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "validators",
         "xlrd==1.2.0",
         "openpyxl",
-        "Shapely",
+        "Shapely==1.8.0",  # Version locking till https://github.com/shapely/shapely/issues/1364 is fixed
         "SPARQLWrapper",
         "pluggy",
         "sqlalchemy",


### PR DESCRIPTION
Needs locking till https://github.com/shapely/shapely/issues/1364 is fixed

See https://trello.com/c/TqI17wXY/2516-listed-building-collection-failing-on-bucks-geometry

We should really enforce transactionality on a resource level in our pipeline so one bad geometry can't break the whole pipeline