### PR TITLE
Remove external test target from combined `test` target

### DIFF
--- a/makerules/python.mk
+++ b/makerules/python.mk
@@ -14,7 +14,7 @@ black:
 flake8:
 	flake8 .
 
-test:: test-unit test-integration test-e2e test-airflow
+test:: test-unit test-integration test-e2e
 
 test-unit:
 	[ -d tests/unit ] && python -m pytest tests/unit --junitxml=.junitxml/unit.xml


### PR DESCRIPTION
Remove external test target that was added during the airflow spike to perform interface/integration tests against digital-land-python