### PR TITLE
Feat/expectation suite

### DIFF
--- a/digital_land/expectations/core.py
+++ b/digital_land/expectations/core.py
@@ -9,6 +9,7 @@ import warnings
 import copy
 import os
 
+
 def transform_df_first_column_into_set(dataframe: pd.DataFrame) -> set:
     "Given a pd dataframe returns the first column as a python set"
     return set(dataframe.iloc[:, 0].unique())
@@ -73,12 +74,14 @@ class SeverityEnum(str, Enum):
     Enumeration for severity csv in specification, may need to be replaced in the future
     with a different mechanism to read from csv
     """
-    critical = 'critical'
-    error = 'error'
-    warning = 'warning'
-    notice = 'notice'
-    info = 'info'
-    debug = 'debug'
+
+    critical = "critical"
+    error = "error"
+    warning = "warning"
+    notice = "notice"
+    info = "info"
+    debug = "debug"
+
 
 # TODO write unit tests for this class
 @dataclass_json
@@ -144,6 +147,7 @@ class ExpectationResponse:
                 failure_count = 1
 
         return failure_count
+
 
 # expectation_input = {
 #         key: value

--- a/digital_land/expectations/core.py
+++ b/digital_land/expectations/core.py
@@ -1,7 +1,7 @@
 import spatialite
 import pandas as pd
 import yaml
-from dataclasses import dataclass
+from pydantic.dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from enum import Enum
 from datetime import datetime

--- a/digital_land/expectations/core.py
+++ b/digital_land/expectations/core.py
@@ -1,7 +1,7 @@
 import spatialite
 import pandas as pd
 import yaml
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from enum import Enum
 from datetime import datetime

--- a/digital_land/expectations/core.py
+++ b/digital_land/expectations/core.py
@@ -3,11 +3,11 @@ import pandas as pd
 import yaml
 from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
+from enum import Enum
 from datetime import datetime
 import warnings
 import copy
 import os
-
 
 def transform_df_first_column_into_set(dataframe: pd.DataFrame) -> set:
     "Given a pd dataframe returns the first column as a python set"
@@ -68,6 +68,18 @@ class QueryRunner:
             return results
 
 
+class SeverityEnum(str, Enum):
+    """
+    Enumeration for severity csv in specification, may need to be replaced in the future
+    with a different mechanism to read from csv
+    """
+    critical = 'critical'
+    error = 'error'
+    warning = 'warning'
+    notice = 'notice'
+    info = 'info'
+    debug = 'debug'
+
 # TODO write unit tests for this class
 @dataclass_json
 @dataclass
@@ -76,6 +88,7 @@ class ExpectationResponse:
 
     expectation_input: dict
     result: bool = None
+    severity: SeverityEnum = None
     msg: str = None
     details: dict = None
     data_name: str = None
@@ -83,13 +96,10 @@ class ExpectationResponse:
     name: str = None
     description: str = None
     expectation: str = None
-    entry_date: str = field(init=False)
-    severity: str = None
+    entry_date: str = None
 
     def __post_init__(self):
         "Adds a few more interesting items and adjusts response for log"
-
-        self.expectation_input.pop("query_runner")
 
         check_for_kwargs = self.expectation_input.get("kwargs", None)
         if check_for_kwargs:
@@ -120,13 +130,23 @@ class ExpectationResponse:
             f.write(self_save_version.to_json())
 
     def act_on_failure(self):
-        "Raises error if severity is RaiseError or shows warning if severity is LogWarning"
+        """
+        Returns 1 if severity is critical or 0 if severity is not critical
+        raises a warning for failed tests
+        Could be moved to expection suite class
+        """
 
-        result = 0
+        failure_count = 0
 
         if not self.result:
             warnings.warn(self.msg)
-            if self.severity == "RaiseError":
-                result = 1
+            if self.severity == "critical":
+                failure_count = 1
 
-        return result
+        return failure_count
+
+# expectation_input = {
+#         key: value
+#         for key, value in locals().items()
+#         if key not in ["name", "description", "expectation_severity"]
+#     }

--- a/digital_land/expectations/expectations.py
+++ b/digital_land/expectations/expectations.py
@@ -1,8 +1,6 @@
-import inspect
 import pandas as pd
-from .core import QueryRunner, ExpectationResponse
+from .core import QueryRunner
 from math import inf
-from pathlib import Path
 import logging
 
 

--- a/digital_land/expectations/expectations.py
+++ b/digital_land/expectations/expectations.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import logging
 
 
-
 def expect_database_to_have_set_of_tables(
     query_runner: QueryRunner,
     expected_tables_set: set,
@@ -41,7 +40,7 @@ def expect_database_to_have_set_of_tables(
             "found_tables": found_tables_set,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_table_to_have_set_of_columns(
@@ -79,7 +78,7 @@ def expect_table_to_have_set_of_columns(
             "found_columns": found_columns_set,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_table_row_count_to_be_in_range(
@@ -110,7 +109,7 @@ def expect_table_row_count_to_be_in_range(
             "max_expected": max_expected_row_count,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_row_count_for_lookup_value_to_be_in_range(
@@ -166,7 +165,7 @@ def expect_row_count_for_lookup_value_to_be_in_range(
         msg = f"Fail: table '{table_name}': one or more counts per lookup_value not in expected range see for more info see details"
         details = found_not_within_range.to_dict(orient="records")
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_field_values_to_be_within_set(
@@ -211,7 +210,7 @@ def expect_field_values_to_be_within_set(
             "found_values": found_values_set,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_values_for_field_to_be_unique(
@@ -239,7 +238,7 @@ def expect_values_for_field_to_be_unique(
         msg = f"Fail: duplicate values for the combined fields '{fields}' on table '{table_name}', see details"
         details = {"duplicates_found": found_duplicity.to_dict(orient="records")}
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_geoshapes_to_be_valid(
@@ -271,7 +270,7 @@ def expect_geoshapes_to_be_valid(
         msg = f"Fail: {len(invalid_shapes)} invalid shapes found in field '{shape_field}' on table '{table_name}', see details"
         details = {"invalid_shapes": invalid_shapes.to_dict(orient="records")}
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_values_for_a_key_stored_in_json_are_within_a_set(
@@ -319,7 +318,7 @@ def expect_values_for_a_key_stored_in_json_are_within_a_set(
         msg = f"Fail: found non-expected values for key '{json_key}' in field '{field}' on table '{table_name}', see details"
         details = {"non_expected_values": non_expected_values.to_dict(orient="records")}
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_keys_in_json_field_to_be_in_set_of_options(
@@ -365,7 +364,7 @@ def expect_keys_in_json_field_to_be_in_set_of_options(
             )
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_values_in_field_to_be_within_range(
@@ -400,7 +399,7 @@ def expect_values_in_field_to_be_within_range(
             )
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_custom_query_result_to_be_as_predicted(
@@ -435,7 +434,7 @@ def expect_custom_query_result_to_be_as_predicted(
             "expected_query_result": expected_query_result,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
@@ -518,7 +517,7 @@ def expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
                 )
             }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_entities_to_intersect_given_geometry_to_be_as_predicted(
@@ -549,7 +548,7 @@ def expect_entities_to_intersect_given_geometry_to_be_as_predicted(
             "expected_query_result": expected_result,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_count_of_entities_to_intersect_given_geometry_to_be_as_predicted(
@@ -576,7 +575,7 @@ def expect_count_of_entities_to_intersect_given_geometry_to_be_as_predicted(
             "expected_result": expected_result,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_total_count_of_entities_in_dataset_to_be_as_predicted(
@@ -600,7 +599,7 @@ def expect_total_count_of_entities_in_dataset_to_be_as_predicted(
             "expected_result": expected_result,
         }
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_count_of_entities_in_given_organisations_to_be_as_predicted(
@@ -628,7 +627,7 @@ def expect_count_of_entities_in_given_organisations_to_be_as_predicted(
     else:
         msg = "Fail: result count is not correct, see details"
 
-    return result,msg,details
+    return result, msg, details
 
 
 def expect_filtered_entities_to_be_as_predicted(
@@ -663,7 +662,7 @@ def expect_filtered_entities_to_be_as_predicted(
     else:
         msg = "Fail: result count is not correct, see details"
 
-    return result,msg,details
+    return result, msg, details
 
 
 def build_entity_select_statement(columns):
@@ -785,7 +784,7 @@ def count_entities(
     else:
         msg = "Fail: result count is not correct, see details"
 
-    return result,msg,details
+    return result, msg, details
 
 
 def compare_entities(
@@ -823,5 +822,4 @@ def compare_entities(
     else:
         msg = "Fail: result is not correct, see details"
 
-
-    return result,msg,details
+    return result, msg, details

--- a/digital_land/expectations/main.py
+++ b/digital_land/expectations/main.py
@@ -1,11 +1,14 @@
 from digital_land.expectations.suite import DatasetExpectationSuite
 
+
 def run_expectation_suite(results_file_path, data_path, expectation_suite_yaml):
-    """ 
-    function to run and expectation suite. currently we only run one for 
+    """
+    function to run and expectation suite. currently we only run one for
     datasets with yaml inputs. this may need to be updated for other inputs
     """
-    expectation_suite = DatasetExpectationSuite(results_file_path,data_path, expectation_suite_yaml)
+    expectation_suite = DatasetExpectationSuite(
+        results_file_path, data_path, expectation_suite_yaml
+    )
     expectation_suite.run_suite()
     expectation_suite.save_responses()
     expectation_suite.act_on_critical_error()

--- a/digital_land/expectations/main.py
+++ b/digital_land/expectations/main.py
@@ -1,67 +1,11 @@
-from .core import QueryRunner, config_parser, DataQualityException
-from datetime import datetime
-from .expectations import *  # noqa
-import warnings
-from csv import DictWriter
-
+from digital_land.expectations.suite import DatasetExpectationSuite
 
 def run_expectation_suite(results_file_path, data_path, expectation_suite_yaml):
-
-    now = datetime.now()
-    entry_date = now.isoformat()
-    expectation_suite_config = config_parser(expectation_suite_yaml)
-
-    if expectation_suite_config is None:
-        warnings.warn(
-            "either empty yaml file being provided or no yaml file being found"
-        )
-        return
-
-    query_runner = QueryRunner(data_path)
-
-    expectations = expectation_suite_config.get("expectations", None)
-
-    failed_expectation_with_error_severity = 0
-
-    responses = []
-    for expectation in expectations:
-        arguments = {**expectation}
-
-        response = run_expectation(
-            query_runner=query_runner,
-            entry_date=entry_date,
-            **arguments,
-        )
-
-        responses.append(response.to_dict())
-
-        failed_expectation_with_error_severity += response.act_on_failure()
-
-    # data_path_hash = hashlib.sha256(data_path.encode('UTF-8')).hexdigest()
-    # file_name = f"{suite_execution_time}_{data_path_hash}.json"
-    with open(results_file_path, "w") as f:
-        fieldnames = [
-            "entry_date",
-            "name",
-            "description",
-            "expectation",
-            "severity",
-            "result",
-            "msg",
-            "details",
-            "data_name",
-            "data_path",
-            "expectation_input",
-        ]
-        dictwriter = DictWriter(f, fieldnames=fieldnames)
-        dictwriter.writeheader()
-        dictwriter.writerows(responses)
-
-    if failed_expectation_with_error_severity > 0:
-        raise DataQualityException(
-            "One or more expectations with severity RaiseError failed, see results for more details"
-        )
-
-
-def run_expectation(query_runner: QueryRunner, expectation: str, **kwargs):
-    return globals()[expectation](query_runner=query_runner, **kwargs)
+    """ 
+    function to run and expectation suite. currently we only run one for 
+    datasets with yaml inputs. this may need to be updated for other inputs
+    """
+    expectation_suite = DatasetExpectationSuite(results_file_path,data_path, expectation_suite_yaml)
+    expectation_suite.run_suite()
+    expectation_suite.save_responses()
+    expectation_suite.act_on_critical_error()

--- a/digital_land/expectations/suite.py
+++ b/digital_land/expectations/suite.py
@@ -6,19 +6,23 @@ from csv import DictWriter
 import logging
 import os
 
-from digital_land.expectations.core import QueryRunner, DataQualityException, ExpectationResponse
+from digital_land.expectations.core import (
+    QueryRunner,
+    DataQualityException,
+    ExpectationResponse,
+)
 import digital_land.expectations.expectations as expectations
 
 
 class DatasetExpectationSuite:
-    def __init__(self,results_file_path, data_path, expectation_suite_yaml):
+    def __init__(self, results_file_path, data_path, expectation_suite_yaml):
         self.results_file_path = results_file_path
         self.data_path = data_path
         self.data_name = Path(data_path).stem
         self.expectation_suite_yaml = expectation_suite_yaml
         self.query_runner = QueryRunner(self.data_path)
 
-    def config_parser(self,filepath):
+    def config_parser(self, filepath):
         "Will parse a config file"
         try:
             with open(filepath) as file:
@@ -26,32 +30,32 @@ class DatasetExpectationSuite:
                 if config is not None:
                     config = dict(config)
                 else:
-                    warnings.warn('empty yaml file provided')
+                    warnings.warn("empty yaml file provided")
 
         except OSError:
-            warnings.warn('no yaml file found')
-            config= None
+            warnings.warn("no yaml file found")
+            config = None
         return config
 
-    def run_expectation(self,expectation):
+    def run_expectation(self, expectation):
         arguments = {**expectation}
-        expectation_function=getattr(expectations,expectation['expectation']) 
+        expectation_function = getattr(expectations, expectation["expectation"])
         result, msg, details = expectation_function(
             query_runner=self.query_runner,
             **arguments,
         )
-        if getattr(self,'responses',None):
-            entry_date =  self.entry_date
+        if getattr(self, "responses", None):
+            entry_date = self.entry_date
         else:
             now = datetime.now()
             entry_date = now.isoformat()
 
         response = ExpectationResponse(
             entry_date=entry_date,
-            name=expectation['name'],
-            description=expectation.get('description',None),
-            expectation=expectation['expectation'],
-            severity=expectation['severity'],
+            name=expectation["name"],
+            description=expectation.get("description", None),
+            expectation=expectation["expectation"],
+            severity=expectation["severity"],
             result=result,
             msg=msg,
             details=details,
@@ -61,36 +65,36 @@ class DatasetExpectationSuite:
         )
 
         return response
-    
+
     def run_suite(self):
-        self.expectation_suite_config=self.config_parser(self.expectation_suite_yaml)
+        self.expectation_suite_config = self.config_parser(self.expectation_suite_yaml)
         if not self.expectation_suite_config:
             return
 
-        self.responses=[]
+        self.responses = []
         now = datetime.now()
         self.entry_date = now.isoformat()
         self.failed_expectation_with_error_severity = 0
-        
+
         self.expectations = self.expectation_suite_config.get("expectations", None)
         for expectation in self.expectations:
             response = self.run_expectation(expectation)
             self.responses.append(response)
             self.failed_expectation_with_error_severity += response.act_on_failure()
-    
+
         if self.failed_expectation_with_error_severity > 0:
             raise DataQualityException(
                 "One or more expectations with severity RaiseError failed, see results for more details"
             )
-    
-    def save_responses(self,responses=None,results_path=None):
+
+    def save_responses(self, responses=None, results_path=None):
         if responses is None:
-            responses=getattr(self,'responses',None)
-        
+            responses = getattr(self, "responses", None)
+
         if responses:
             if results_path == None:
-                results_path=self.results_file_path
-            fieldnames=responses[0].__annotations__.keys()
+                results_path = self.results_file_path
+            fieldnames = responses[0].__annotations__.keys()
             responses_as_dicts = [response.to_dict() for response in responses]
 
             os.makedirs(os.path.dirname(results_path), exist_ok=True)
@@ -98,10 +102,10 @@ class DatasetExpectationSuite:
                 dictwriter = DictWriter(f, fieldnames=fieldnames)
                 dictwriter.writeheader()
                 dictwriter.writerows(responses_as_dicts)
-    
-    def act_on_critical_error(self,failed_expectation_with_error_severity=None):
+
+    def act_on_critical_error(self, failed_expectation_with_error_severity=None):
         if failed_expectation_with_error_severity is None:
-           getattr(self,'failed_expectation_with_error_severity',None)
+            getattr(self, "failed_expectation_with_error_severity", None)
 
         if failed_expectation_with_error_severity:
             if failed_expectation_with_error_severity > 0:

--- a/digital_land/expectations/suite.py
+++ b/digital_land/expectations/suite.py
@@ -1,0 +1,110 @@
+import yaml
+import warnings
+from datetime import datetime
+from pathlib import Path
+from csv import DictWriter
+import logging
+import os
+
+from digital_land.expectations.core import QueryRunner, DataQualityException, ExpectationResponse
+import digital_land.expectations.expectations as expectations
+
+
+class DatasetExpectationSuite:
+    def __init__(self,results_file_path, data_path, expectation_suite_yaml):
+        self.results_file_path = results_file_path
+        self.data_path = data_path
+        self.data_name = Path(data_path).stem
+        self.expectation_suite_yaml = expectation_suite_yaml
+        self.query_runner = QueryRunner(self.data_path)
+
+    def config_parser(self,filepath):
+        "Will parse a config file"
+        try:
+            with open(filepath) as file:
+                config = yaml.load(file, Loader=yaml.FullLoader)
+                if config is not None:
+                    config = dict(config)
+                else:
+                    warnings.warn('empty yaml file provided')
+
+        except OSError:
+            warnings.warn('no yaml file found')
+            config= None
+        return config
+
+    def run_expectation(self,expectation):
+        arguments = {**expectation}
+        expectation_function=getattr(expectations,expectation['expectation']) 
+        result, msg, details = expectation_function(
+            query_runner=self.query_runner,
+            **arguments,
+        )
+        if getattr(self,'responses',None):
+            entry_date =  self.entry_date
+        else:
+            now = datetime.now()
+            entry_date = now.isoformat()
+
+        response = ExpectationResponse(
+            entry_date=entry_date,
+            name=expectation['name'],
+            description=expectation.get('description',None),
+            expectation=expectation['expectation'],
+            severity=expectation['severity'],
+            result=result,
+            msg=msg,
+            details=details,
+            data_name=self.data_name,
+            data_path=self.data_path,
+            expectation_input={**expectation},
+        )
+
+        return response
+    
+    def run_suite(self):
+        self.expectation_suite_config=self.config_parser(self.expectation_suite_yaml)
+        if not self.expectation_suite_config:
+            return
+
+        self.responses=[]
+        now = datetime.now()
+        self.entry_date = now.isoformat()
+        self.failed_expectation_with_error_severity = 0
+        
+        self.expectations = self.expectation_suite_config.get("expectations", None)
+        for expectation in self.expectations:
+            response = self.run_expectation(expectation)
+            self.responses.append(response)
+            self.failed_expectation_with_error_severity += response.act_on_failure()
+    
+        if self.failed_expectation_with_error_severity > 0:
+            raise DataQualityException(
+                "One or more expectations with severity RaiseError failed, see results for more details"
+            )
+    
+    def save_responses(self,responses=None,results_path=None):
+        if responses is None:
+            responses=getattr(self,'responses',None)
+        
+        if responses:
+            if results_path == None:
+                results_path=self.results_file_path
+            fieldnames=responses[0].__annotations__.keys()
+            responses_as_dicts = [response.to_dict() for response in responses]
+
+            os.makedirs(os.path.dirname(results_path), exist_ok=True)
+            with open(results_path, "w") as f:
+                dictwriter = DictWriter(f, fieldnames=fieldnames)
+                dictwriter.writeheader()
+                dictwriter.writerows(responses_as_dicts)
+    
+    def act_on_critical_error(self,failed_expectation_with_error_severity=None):
+        if failed_expectation_with_error_severity is None:
+           getattr(self,'failed_expectation_with_error_severity',None)
+
+        if failed_expectation_with_error_severity:
+            if failed_expectation_with_error_severity > 0:
+                raise DataQualityException(
+                    "One or more expectations with severity RaiseError failed, see results for more details"
+                )

--- a/digital_land/expectations/suite.py
+++ b/digital_land/expectations/suite.py
@@ -3,7 +3,6 @@ import warnings
 from datetime import datetime
 from pathlib import Path
 from csv import DictWriter
-import logging
 import os
 
 from digital_land.expectations.core import (
@@ -92,7 +91,7 @@ class DatasetExpectationSuite:
             responses = getattr(self, "responses", None)
 
         if responses:
-            if results_path == None:
+            if results_path is None:
                 results_path = self.results_file_path
             fieldnames = responses[0].__annotations__.keys()
             responses_as_dicts = [response.to_dict() for response in responses]

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "spatialite",
         "pyyaml",
         "dataclasses-json",
-        "pydantic"
+        "pydantic",
     ],
     entry_points={"console_scripts": ["digital-land=digital_land.cli:cli"]},
     setup_requires=["pytest-runner"],
@@ -64,7 +64,7 @@ setup(
             "responses",
             "XlsxWriter",
             "wasabi",
-            "pytest-mock"
+            "pytest-mock",
         ]
         + maybe_black
     },

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "spatialite",
         "pyyaml",
         "dataclasses-json",
+        "pydantic"
     ],
     entry_points={"console_scripts": ["digital-land=digital_land.cli:cli"]},
     setup_requires=["pytest-runner"],
@@ -63,6 +64,7 @@ setup(
             "responses",
             "XlsxWriter",
             "wasabi",
+            "pytest-mock"
         ]
         + maybe_black
     },

--- a/tests/integration/expectations/test_expectations.py
+++ b/tests/integration/expectations/test_expectations.py
@@ -58,16 +58,14 @@ def test_expect_filtered_entities_to_be_as_predicted_runs_for_correct_input(
     filters = {"reference": "1"}
 
     # run expectation
-    result,msg,details = expect_filtered_entities_to_be_as_predicted(
+    result, msg, details = expect_filtered_entities_to_be_as_predicted(
         query_runner=query_runner,
         columns=columns,
         expected_result=expected_result,
         filters=filters,
     )
 
-    assert (
-        result
-    ), f"Expectation Details: {details}"
+    assert result, f"Expectation Details: {details}"
 
 
 def test_expect_filtered_entities_to_be_as_predicted_fails(
@@ -88,16 +86,14 @@ def test_expect_filtered_entities_to_be_as_predicted_fails(
     filters = {"reference": "1"}
 
     # run expectation
-    result,msg,details = expect_filtered_entities_to_be_as_predicted(
+    result, msg, details = expect_filtered_entities_to_be_as_predicted(
         query_runner=query_runner,
         expected_result=expected_result,
         columns=columns,
         filters=filters,
     )
 
-    assert (
-        not result
-    ), f"Expectation Details: {details}"
+    assert not result, f"Expectation Details: {details}"
 
 
 def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_passes(
@@ -124,18 +120,18 @@ def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_passes(
     geometry = "POINT(-0.460759538145794 52.94701402037683)"
 
     # run expectation
-    result,msg,details = (
-        expect_entities_to_intersect_given_geometry_to_be_as_predicted(
-            query_runner=query_runner,
-            expected_result=expected_result,
-            returned_entity_fields=returned_entity_fields,
-            geometry=geometry,
-        )
+    (
+        result,
+        msg,
+        details,
+    ) = expect_entities_to_intersect_given_geometry_to_be_as_predicted(
+        query_runner=query_runner,
+        expected_result=expected_result,
+        returned_entity_fields=returned_entity_fields,
+        geometry=geometry,
     )
 
-    assert (
-        result
-    ), f"Expectation Details: {details}"
+    assert result, f"Expectation Details: {details}"
 
 
 def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_fails(
@@ -162,18 +158,18 @@ def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_fails(
     geometry = "POINT(-0.4581196580693358 52.947003722396005)"
 
     # run expectation
-    result,details,msg = (
-        expect_entities_to_intersect_given_geometry_to_be_as_predicted(
-            query_runner=query_runner,
-            expected_result=expected_result,
-            returned_entity_fields=returned_entity_fields,
-            geometry=geometry,
-        )
+    (
+        result,
+        details,
+        msg,
+    ) = expect_entities_to_intersect_given_geometry_to_be_as_predicted(
+        query_runner=query_runner,
+        expected_result=expected_result,
+        returned_entity_fields=returned_entity_fields,
+        geometry=geometry,
     )
 
-    assert (
-        not result
-    ), f"Expectation Details: {details}"
+    assert not result, f"Expectation Details: {details}"
 
 
 def test_count_entities_passes(sqlite3_with_entity_table_path):
@@ -196,13 +192,11 @@ def test_count_entities_passes(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
 
     # run expectation
-    result,msg,details = count_entities(
+    result, msg, details = count_entities(
         query_runner=query_runner, expected_result=expected_result, filters=filters
     )
 
-    assert (
-        result
-    ), f"Expectation Details: {details}"
+    assert result, f"Expectation Details: {details}"
 
 
 def test_count_entities_fails(sqlite3_with_entity_table_path):
@@ -225,13 +219,11 @@ def test_count_entities_fails(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.4581196580693358 52.947003722396005)"}
 
     # run expectation
-    result,msg,details = count_entities(
+    result, msg, details = count_entities(
         query_runner=query_runner, expected_result=expected_result, filters=filters
     )
 
-    assert (
-        not result
-    ), f"Expectation Details: {details}"
+    assert not result, f"Expectation Details: {details}"
 
 
 def test_compare_entities_passes(sqlite3_with_entity_table_path):
@@ -255,16 +247,14 @@ def test_compare_entities_passes(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
 
     # run expectation
-    result,msg,details = compare_entities(
+    result, msg, details = compare_entities(
         query_runner=query_runner,
         expected_result=expected_result,
         columns=columns,
         filters=filters,
     )
 
-    assert (
-        result
-    ), f"Expectation Details: {details}"
+    assert result, f"Expectation Details: {details}"
 
 
 def test_compare_entities_fails(sqlite3_with_entity_table_path):
@@ -288,13 +278,11 @@ def test_compare_entities_fails(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.4581196580693358 52.947003722396005)"}
 
     # run expectation
-    result,msg,details = compare_entities(
+    result, msg, details = compare_entities(
         query_runner=query_runner,
         expected_result=expected_result,
         columns=columns,
         filters=filters,
     )
 
-    assert (
-        not result
-    ), f"Expectation Details: {details}"
+    assert not result, f"Expectation Details: {details}"

--- a/tests/integration/expectations/test_expectations.py
+++ b/tests/integration/expectations/test_expectations.py
@@ -58,7 +58,7 @@ def test_expect_filtered_entities_to_be_as_predicted_runs_for_correct_input(
     filters = {"reference": "1"}
 
     # run expectation
-    expectation_response = expect_filtered_entities_to_be_as_predicted(
+    result,msg,details = expect_filtered_entities_to_be_as_predicted(
         query_runner=query_runner,
         columns=columns,
         expected_result=expected_result,
@@ -66,8 +66,8 @@ def test_expect_filtered_entities_to_be_as_predicted_runs_for_correct_input(
     )
 
     assert (
-        expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        result
+    ), f"Expectation Details: {details}"
 
 
 def test_expect_filtered_entities_to_be_as_predicted_fails(
@@ -88,7 +88,7 @@ def test_expect_filtered_entities_to_be_as_predicted_fails(
     filters = {"reference": "1"}
 
     # run expectation
-    expectation_response = expect_filtered_entities_to_be_as_predicted(
+    result,msg,details = expect_filtered_entities_to_be_as_predicted(
         query_runner=query_runner,
         expected_result=expected_result,
         columns=columns,
@@ -96,8 +96,8 @@ def test_expect_filtered_entities_to_be_as_predicted_fails(
     )
 
     assert (
-        not expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        not result
+    ), f"Expectation Details: {details}"
 
 
 def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_passes(
@@ -124,7 +124,7 @@ def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_passes(
     geometry = "POINT(-0.460759538145794 52.94701402037683)"
 
     # run expectation
-    expectation_response = (
+    result,msg,details = (
         expect_entities_to_intersect_given_geometry_to_be_as_predicted(
             query_runner=query_runner,
             expected_result=expected_result,
@@ -134,8 +134,8 @@ def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_passes(
     )
 
     assert (
-        expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        result
+    ), f"Expectation Details: {details}"
 
 
 def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_fails(
@@ -162,7 +162,7 @@ def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_fails(
     geometry = "POINT(-0.4581196580693358 52.947003722396005)"
 
     # run expectation
-    expectation_response = (
+    result,details,msg = (
         expect_entities_to_intersect_given_geometry_to_be_as_predicted(
             query_runner=query_runner,
             expected_result=expected_result,
@@ -172,8 +172,8 @@ def test_expect_entities_to_intersect_given_geometry_to_be_as_predicted_fails(
     )
 
     assert (
-        not expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        not result
+    ), f"Expectation Details: {details}"
 
 
 def test_count_entities_passes(sqlite3_with_entity_table_path):
@@ -196,13 +196,13 @@ def test_count_entities_passes(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
 
     # run expectation
-    expectation_response = count_entities(
+    result,msg,details = count_entities(
         query_runner=query_runner, expected_result=expected_result, filters=filters
     )
 
     assert (
-        expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        result
+    ), f"Expectation Details: {details}"
 
 
 def test_count_entities_fails(sqlite3_with_entity_table_path):
@@ -225,13 +225,13 @@ def test_count_entities_fails(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.4581196580693358 52.947003722396005)"}
 
     # run expectation
-    expectation_response = count_entities(
+    result,msg,details = count_entities(
         query_runner=query_runner, expected_result=expected_result, filters=filters
     )
 
     assert (
-        not expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        not result
+    ), f"Expectation Details: {details}"
 
 
 def test_compare_entities_passes(sqlite3_with_entity_table_path):
@@ -255,7 +255,7 @@ def test_compare_entities_passes(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
 
     # run expectation
-    expectation_response = compare_entities(
+    result,msg,details = compare_entities(
         query_runner=query_runner,
         expected_result=expected_result,
         columns=columns,
@@ -263,8 +263,8 @@ def test_compare_entities_passes(sqlite3_with_entity_table_path):
     )
 
     assert (
-        expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        result
+    ), f"Expectation Details: {details}"
 
 
 def test_compare_entities_fails(sqlite3_with_entity_table_path):
@@ -288,7 +288,7 @@ def test_compare_entities_fails(sqlite3_with_entity_table_path):
     filters = {"geometry": "POINT(-0.4581196580693358 52.947003722396005)"}
 
     # run expectation
-    expectation_response = compare_entities(
+    result,msg,details = compare_entities(
         query_runner=query_runner,
         expected_result=expected_result,
         columns=columns,
@@ -296,5 +296,5 @@ def test_compare_entities_fails(sqlite3_with_entity_table_path):
     )
 
     assert (
-        not expectation_response.result
-    ), f"Expectation Details: {expectation_response.details}"
+        not result
+    ), f"Expectation Details: {details}"

--- a/tests/integration/expectations/test_main.py
+++ b/tests/integration/expectations/test_main.py
@@ -1,7 +1,11 @@
 import pytest
 import os
-
+import spatialite
+import yaml
+import pandas as pd
+from csv import DictReader
 from digital_land.expectations.main import run_expectation_suite
+from digital_land.expectations.core import DataQualityException
 
 
 def test_run_expectation_suite_raises_warning(tmp_path):
@@ -10,3 +14,100 @@ def test_run_expectation_suite_raises_warning(tmp_path):
         data_path = os.path.join(tmp_path, "data.sqlite3")
         expectation_suite_yaml = os.path.join(tmp_path, "suite.yaml")
         run_expectation_suite(results_file_path, data_path, expectation_suite_yaml)
+
+@pytest.fixture
+def sqlite3_with_entity_table_path(tmp_path):
+    dataset_path = os.path.join(tmp_path, "test.sqlite3")
+
+    create_table_sql = """
+        CREATE TABLE entity (
+            dataset TEXT,
+            end_date TEXT,
+            entity INTEGER PRIMARY KEY,
+            entry_date TEXT,
+            geojson JSON,
+            geometry TEXT,
+            json JSON,
+            name TEXT,
+            organisation_entity TEXT,
+            point TEXT,
+            prefix TEXT,
+            reference TEXT,
+            start_date TEXT,
+            typology TEXT
+        );
+    """
+    with spatialite.connect(dataset_path) as con:
+        con.execute(create_table_sql)
+
+    return dataset_path
+
+def test_run_expectation_suite_success(tmp_path,sqlite3_with_entity_table_path):
+    # load data
+    multipolygon = (
+        "MULTIPOLYGON(((-0.4610469722185172 52.947516855690964,"
+        "-0.4614606467578964 52.94650314047493,"
+        "-0.4598136600343151 52.94695770522492,"
+        "-0.4610469722185172 52.947516855690964)))"
+    )
+    test_data = pd.DataFrame.from_dict(
+        {"entity": [1], "name": ["test1"], "geometry": [multipolygon]}
+    )
+    with spatialite.connect(sqlite3_with_entity_table_path) as con:
+        test_data.to_sql("entity", con, if_exists="append", index=False)
+    
+    # create yaml
+    filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
+    yaml_dict = {'expectations':[{'severity':'critical','name':'count entities','expectation':'count_entities','filters':filters,'expected_result':1}]}
+    with open(os.path.join(tmp_path,'suite.yaml'), 'w') as yaml_file: 
+        yaml.dump(yaml_dict,yaml_file)
+
+    # build inputs
+    results_file_path = os.path.join(tmp_path, "results.csv")
+    data_path = sqlite3_with_entity_table_path
+    expectation_suite_yaml = os.path.join(tmp_path, "suite.yaml")
+    run_expectation_suite(results_file_path, data_path, expectation_suite_yaml)
+
+    # get results
+    actual = []
+    with open(os.path.join(tmp_path,'results.csv')) as file:
+        reader = DictReader(file)
+        for row in reader:
+            actual.append(row)
+
+    # check results true
+    assert actual[0]['result']
+
+
+def test_run_expectation_suite_fails_with_critical_failure(tmp_path,sqlite3_with_entity_table_path):
+    # load data
+    multipolygon = (
+        "MULTIPOLYGON(((-0.4610469722185172 52.947516855690964,"
+        "-0.4614606467578964 52.94650314047493,"
+        "-0.4598136600343151 52.94695770522492,"
+        "-0.4610469722185172 52.947516855690964)))"
+    )
+    test_data = pd.DataFrame.from_dict(
+        {"entity": [1], "name": ["test1"], "geometry": [multipolygon]}
+    )
+    with spatialite.connect(sqlite3_with_entity_table_path) as con:
+        test_data.to_sql("entity", con, if_exists="append", index=False)
+    
+    # create yaml
+    filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
+    yaml_dict = {'expectations':[{'severity':'critical','name':'count entities','expectation':'count_entities','filters':filters,'expected_result':2}]}
+    with open(os.path.join(tmp_path,'suite.yaml'), 'w') as yaml_file: 
+        yaml.dump(yaml_dict,yaml_file)
+
+    # build inputs
+    results_file_path = os.path.join(tmp_path, "results.csv")
+    data_path = sqlite3_with_entity_table_path
+    expectation_suite_yaml = os.path.join(tmp_path, "suite.yaml")
+
+    try:
+        with pytest.warns(UserWarning):
+            run_expectation_suite(results_file_path, data_path, expectation_suite_yaml)
+        assert False
+    except DataQualityException:
+        assert True
+

--- a/tests/integration/expectations/test_main.py
+++ b/tests/integration/expectations/test_main.py
@@ -15,6 +15,7 @@ def test_run_expectation_suite_raises_warning(tmp_path):
         expectation_suite_yaml = os.path.join(tmp_path, "suite.yaml")
         run_expectation_suite(results_file_path, data_path, expectation_suite_yaml)
 
+
 @pytest.fixture
 def sqlite3_with_entity_table_path(tmp_path):
     dataset_path = os.path.join(tmp_path, "test.sqlite3")
@@ -42,7 +43,8 @@ def sqlite3_with_entity_table_path(tmp_path):
 
     return dataset_path
 
-def test_run_expectation_suite_success(tmp_path,sqlite3_with_entity_table_path):
+
+def test_run_expectation_suite_success(tmp_path, sqlite3_with_entity_table_path):
     # load data
     multipolygon = (
         "MULTIPOLYGON(((-0.4610469722185172 52.947516855690964,"
@@ -55,12 +57,22 @@ def test_run_expectation_suite_success(tmp_path,sqlite3_with_entity_table_path):
     )
     with spatialite.connect(sqlite3_with_entity_table_path) as con:
         test_data.to_sql("entity", con, if_exists="append", index=False)
-    
+
     # create yaml
     filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
-    yaml_dict = {'expectations':[{'severity':'critical','name':'count entities','expectation':'count_entities','filters':filters,'expected_result':1}]}
-    with open(os.path.join(tmp_path,'suite.yaml'), 'w') as yaml_file: 
-        yaml.dump(yaml_dict,yaml_file)
+    yaml_dict = {
+        "expectations": [
+            {
+                "severity": "critical",
+                "name": "count entities",
+                "expectation": "count_entities",
+                "filters": filters,
+                "expected_result": 1,
+            }
+        ]
+    }
+    with open(os.path.join(tmp_path, "suite.yaml"), "w") as yaml_file:
+        yaml.dump(yaml_dict, yaml_file)
 
     # build inputs
     results_file_path = os.path.join(tmp_path, "results.csv")
@@ -70,16 +82,18 @@ def test_run_expectation_suite_success(tmp_path,sqlite3_with_entity_table_path):
 
     # get results
     actual = []
-    with open(os.path.join(tmp_path,'results.csv')) as file:
+    with open(os.path.join(tmp_path, "results.csv")) as file:
         reader = DictReader(file)
         for row in reader:
             actual.append(row)
 
     # check results true
-    assert actual[0]['result']
+    assert actual[0]["result"]
 
 
-def test_run_expectation_suite_fails_with_critical_failure(tmp_path,sqlite3_with_entity_table_path):
+def test_run_expectation_suite_fails_with_critical_failure(
+    tmp_path, sqlite3_with_entity_table_path
+):
     # load data
     multipolygon = (
         "MULTIPOLYGON(((-0.4610469722185172 52.947516855690964,"
@@ -92,12 +106,22 @@ def test_run_expectation_suite_fails_with_critical_failure(tmp_path,sqlite3_with
     )
     with spatialite.connect(sqlite3_with_entity_table_path) as con:
         test_data.to_sql("entity", con, if_exists="append", index=False)
-    
+
     # create yaml
     filters = {"geometry": "POINT(-0.460759538145794 52.94701402037683)"}
-    yaml_dict = {'expectations':[{'severity':'critical','name':'count entities','expectation':'count_entities','filters':filters,'expected_result':2}]}
-    with open(os.path.join(tmp_path,'suite.yaml'), 'w') as yaml_file: 
-        yaml.dump(yaml_dict,yaml_file)
+    yaml_dict = {
+        "expectations": [
+            {
+                "severity": "critical",
+                "name": "count entities",
+                "expectation": "count_entities",
+                "filters": filters,
+                "expected_result": 2,
+            }
+        ]
+    }
+    with open(os.path.join(tmp_path, "suite.yaml"), "w") as yaml_file:
+        yaml.dump(yaml_dict, yaml_file)
 
     # build inputs
     results_file_path = os.path.join(tmp_path, "results.csv")
@@ -110,4 +134,3 @@ def test_run_expectation_suite_fails_with_critical_failure(tmp_path,sqlite3_with
         assert False
     except DataQualityException:
         assert True
-

--- a/tests/integration/expectations/test_suite.py
+++ b/tests/integration/expectations/test_suite.py
@@ -1,0 +1,132 @@
+import pytest
+import logging
+import os
+import yaml
+from csv import DictReader
+
+from digital_land.expectations.suite import DatasetExpectationSuite
+from digital_land.expectations.core import ExpectationResponse,DataQualityException
+
+
+def test_config_parser_success(tmp_path):
+    yaml_dict = {'expectations':[{'expectation':'test'}]}
+    with open(os.path.join(tmp_path,'expectations.yaml'), 'w') as yaml_file: 
+        yaml.dump(yaml_dict,yaml_file)
+
+    results_file_path=os.path.join(tmp_path,'results.csv')
+    data_path=os.path.join(tmp_path,'results.csv')
+    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    
+    config = suite.config_parser(expectation_suite_yaml)
+    
+    assert config == yaml_dict
+
+def test_config_parser_no_file(tmp_path):
+
+    # set inputs
+    results_file_path=os.path.join(tmp_path,'results.csv')
+    data_path=os.path.join(tmp_path,'results.csv')
+    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    
+    with pytest.warns(UserWarning):
+        config = suite.config_parser(expectation_suite_yaml)
+    
+    assert config is None
+
+def test_config_parser_empty_file(tmp_path):
+
+    with open(os.path.join(tmp_path,'expectations.yaml'), 'w') as yaml_file: 
+        pass
+
+    results_file_path=os.path.join(tmp_path,'results.csv')
+    data_path=os.path.join(tmp_path,'results.csv')
+    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    
+    with pytest.warns(UserWarning):
+        config = suite.config_parser(expectation_suite_yaml)
+    
+    assert config is None
+
+@pytest.fixture
+def test_expectation_function():
+    def simple_expectation(number_1,number_2,**kwargs):
+        result = number_1 > number_2
+        if result:
+            msg = 'Success'
+        else:
+            msg= 'Fail'
+        
+        details = {'number_1':number_1,'number_2':number_2}
+        return result,msg,details
+    
+    return simple_expectation
+
+def test_run_expectation_suite(mocker,tmp_path,test_expectation_function):
+    # save yaml
+    yaml_dict = {'expectations':[{'severity':'critical','name':'number 1 is bigger than number 2','expectation':'test_expectation_function','number_1':5,'number_2':2}]}
+    with open(os.path.join(tmp_path,'expectations.yaml'), 'w') as yaml_file: 
+        yaml.dump(yaml_dict,yaml_file)
+
+    # mock expectation function
+    class MockExpectationFunctions:
+        def __init__(self,test_expectation_function):
+            self.test_expectation_function = test_expectation_function
+    
+    mocker.patch('digital_land.expectations.suite.expectations', MockExpectationFunctions(test_expectation_function=test_expectation_function))
+    
+
+    # set inputs
+    results_file_path=os.path.join(tmp_path,'results.csv')
+    data_path=os.path.join(tmp_path,'test.sqlite3')
+    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+
+    # create and run suite
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    suite.run_suite()
+
+    response = suite.responses[0]
+
+    assert response.result
+
+@pytest.fixture
+def example_response():
+    response = ExpectationResponse(
+        expectation_input = {'severity':'critical','name':'number 1 is bigger than number 2','expectation':'test_expectation_function','number_1':5,'number_2':2},
+        result= True,
+        severity = 'critical',
+        msg = 'Success',
+        details=None,
+        data_name = 'test',
+        data_path = 'test.sqlite3',
+        name = 'number 1 is bigger than number 2',
+        description = None,
+        expectation = 'test_expectation_function',
+        entry_date= None
+    )
+    return response
+
+def test_save_responses_success(tmp_path,example_response):
+    
+    #set uputs
+    responses = [example_response]
+    results_file_path=os.path.join(tmp_path,'results/results.csv')
+    data_path=os.path.join(tmp_path,'test.sqlite3')
+    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+
+    # create suite and save responses
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    suite.save_responses(responses=responses)
+
+    # extract results
+    actual = []
+    with open(os.path.join(tmp_path,'results/results.csv')) as file:
+        reader = DictReader(file)
+        for row in reader:
+            actual.append(row)
+    
+    assert responses[0].name == actual[0]['name']
+
+

--- a/tests/integration/expectations/test_suite.py
+++ b/tests/integration/expectations/test_suite.py
@@ -5,7 +5,7 @@ import yaml
 from csv import DictReader
 
 from digital_land.expectations.suite import DatasetExpectationSuite
-from digital_land.expectations.core import ExpectationResponse, DataQualityException
+from digital_land.expectations.core import ExpectationResponse
 
 
 def test_config_parser_success(tmp_path):
@@ -47,7 +47,7 @@ def test_config_parser_no_file(tmp_path):
 
 def test_config_parser_empty_file(tmp_path):
 
-    with open(os.path.join(tmp_path, "expectations.yaml"), "w") as yaml_file:
+    with open(os.path.join(tmp_path, "expectations.yaml"), "w"):
         pass
 
     results_file_path = os.path.join(tmp_path, "results.csv")

--- a/tests/integration/expectations/test_suite.py
+++ b/tests/integration/expectations/test_suite.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 import os
 import yaml
 from csv import DictReader

--- a/tests/integration/expectations/test_suite.py
+++ b/tests/integration/expectations/test_suite.py
@@ -5,128 +5,170 @@ import yaml
 from csv import DictReader
 
 from digital_land.expectations.suite import DatasetExpectationSuite
-from digital_land.expectations.core import ExpectationResponse,DataQualityException
+from digital_land.expectations.core import ExpectationResponse, DataQualityException
 
 
 def test_config_parser_success(tmp_path):
-    yaml_dict = {'expectations':[{'expectation':'test'}]}
-    with open(os.path.join(tmp_path,'expectations.yaml'), 'w') as yaml_file: 
-        yaml.dump(yaml_dict,yaml_file)
+    yaml_dict = {"expectations": [{"expectation": "test"}]}
+    with open(os.path.join(tmp_path, "expectations.yaml"), "w") as yaml_file:
+        yaml.dump(yaml_dict, yaml_file)
 
-    results_file_path=os.path.join(tmp_path,'results.csv')
-    data_path=os.path.join(tmp_path,'results.csv')
-    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
-    
+    results_file_path = os.path.join(tmp_path, "results.csv")
+    data_path = os.path.join(tmp_path, "results.csv")
+    expectation_suite_yaml = os.path.join(tmp_path, "expectations.yaml")
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
+
     config = suite.config_parser(expectation_suite_yaml)
-    
+
     assert config == yaml_dict
+
 
 def test_config_parser_no_file(tmp_path):
 
     # set inputs
-    results_file_path=os.path.join(tmp_path,'results.csv')
-    data_path=os.path.join(tmp_path,'results.csv')
-    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
-    
+    results_file_path = os.path.join(tmp_path, "results.csv")
+    data_path = os.path.join(tmp_path, "results.csv")
+    expectation_suite_yaml = os.path.join(tmp_path, "expectations.yaml")
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
+
     with pytest.warns(UserWarning):
         config = suite.config_parser(expectation_suite_yaml)
-    
+
     assert config is None
+
 
 def test_config_parser_empty_file(tmp_path):
 
-    with open(os.path.join(tmp_path,'expectations.yaml'), 'w') as yaml_file: 
+    with open(os.path.join(tmp_path, "expectations.yaml"), "w") as yaml_file:
         pass
 
-    results_file_path=os.path.join(tmp_path,'results.csv')
-    data_path=os.path.join(tmp_path,'results.csv')
-    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
-    
+    results_file_path = os.path.join(tmp_path, "results.csv")
+    data_path = os.path.join(tmp_path, "results.csv")
+    expectation_suite_yaml = os.path.join(tmp_path, "expectations.yaml")
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
+
     with pytest.warns(UserWarning):
         config = suite.config_parser(expectation_suite_yaml)
-    
+
     assert config is None
+
 
 @pytest.fixture
 def test_expectation_function():
-    def simple_expectation(number_1,number_2,**kwargs):
+    def simple_expectation(number_1, number_2, **kwargs):
         result = number_1 > number_2
         if result:
-            msg = 'Success'
+            msg = "Success"
         else:
-            msg= 'Fail'
-        
-        details = {'number_1':number_1,'number_2':number_2}
-        return result,msg,details
-    
+            msg = "Fail"
+
+        details = {"number_1": number_1, "number_2": number_2}
+        return result, msg, details
+
     return simple_expectation
 
-def test_run_expectation_suite(mocker,tmp_path,test_expectation_function):
+
+def test_run_expectation_suite(mocker, tmp_path, test_expectation_function):
     # save yaml
-    yaml_dict = {'expectations':[{'severity':'critical','name':'number 1 is bigger than number 2','expectation':'test_expectation_function','number_1':5,'number_2':2}]}
-    with open(os.path.join(tmp_path,'expectations.yaml'), 'w') as yaml_file: 
-        yaml.dump(yaml_dict,yaml_file)
+    yaml_dict = {
+        "expectations": [
+            {
+                "severity": "critical",
+                "name": "number 1 is bigger than number 2",
+                "expectation": "test_expectation_function",
+                "number_1": 5,
+                "number_2": 2,
+            }
+        ]
+    }
+    with open(os.path.join(tmp_path, "expectations.yaml"), "w") as yaml_file:
+        yaml.dump(yaml_dict, yaml_file)
 
     # mock expectation function
     class MockExpectationFunctions:
-        def __init__(self,test_expectation_function):
+        def __init__(self, test_expectation_function):
             self.test_expectation_function = test_expectation_function
-    
-    mocker.patch('digital_land.expectations.suite.expectations', MockExpectationFunctions(test_expectation_function=test_expectation_function))
-    
+
+    mocker.patch(
+        "digital_land.expectations.suite.expectations",
+        MockExpectationFunctions(test_expectation_function=test_expectation_function),
+    )
 
     # set inputs
-    results_file_path=os.path.join(tmp_path,'results.csv')
-    data_path=os.path.join(tmp_path,'test.sqlite3')
-    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+    results_file_path = os.path.join(tmp_path, "results.csv")
+    data_path = os.path.join(tmp_path, "test.sqlite3")
+    expectation_suite_yaml = os.path.join(tmp_path, "expectations.yaml")
 
     # create and run suite
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
     suite.run_suite()
 
     response = suite.responses[0]
 
     assert response.result
 
+
 @pytest.fixture
 def example_response():
     response = ExpectationResponse(
-        expectation_input = {'severity':'critical','name':'number 1 is bigger than number 2','expectation':'test_expectation_function','number_1':5,'number_2':2},
-        result= True,
-        severity = 'critical',
-        msg = 'Success',
+        expectation_input={
+            "severity": "critical",
+            "name": "number 1 is bigger than number 2",
+            "expectation": "test_expectation_function",
+            "number_1": 5,
+            "number_2": 2,
+        },
+        result=True,
+        severity="critical",
+        msg="Success",
         details=None,
-        data_name = 'test',
-        data_path = 'test.sqlite3',
-        name = 'number 1 is bigger than number 2',
-        description = None,
-        expectation = 'test_expectation_function',
-        entry_date= None
+        data_name="test",
+        data_path="test.sqlite3",
+        name="number 1 is bigger than number 2",
+        description=None,
+        expectation="test_expectation_function",
+        entry_date=None,
     )
     return response
 
-def test_save_responses_success(tmp_path,example_response):
-    
-    #set uputs
+
+def test_save_responses_success(tmp_path, example_response):
+
+    # set uputs
     responses = [example_response]
-    results_file_path=os.path.join(tmp_path,'results/results.csv')
-    data_path=os.path.join(tmp_path,'test.sqlite3')
-    expectation_suite_yaml=os.path.join(tmp_path,'expectations.yaml')
+    results_file_path = os.path.join(tmp_path, "results/results.csv")
+    data_path = os.path.join(tmp_path, "test.sqlite3")
+    expectation_suite_yaml = os.path.join(tmp_path, "expectations.yaml")
 
     # create suite and save responses
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
     suite.save_responses(responses=responses)
 
     # extract results
     actual = []
-    with open(os.path.join(tmp_path,'results/results.csv')) as file:
+    with open(os.path.join(tmp_path, "results/results.csv")) as file:
         reader = DictReader(file)
         for row in reader:
             actual.append(row)
-    
-    assert responses[0].name == actual[0]['name']
 
-
+    assert responses[0].name == actual[0]["name"]

--- a/tests/unit/expectations/test_core.py
+++ b/tests/unit/expectations/test_core.py
@@ -1,8 +1,10 @@
 import pandas as pd
+import pydantic
 from digital_land.expectations.core import (
     transform_df_first_column_into_set,
     config_parser,
     QueryRunner,
+    ExpectationResponse
 )
 
 
@@ -107,3 +109,24 @@ def test_config_parser():
     }
 
     assert result == expected_dictionary
+
+def test_ExpectationResponse__init__fails_validation():
+    try:
+        ExpectationResponse(
+            expectation_input= {'test':'test1'},
+            result = True,
+            severity = 'invalid_string',
+            msg = 'Success',
+            details = None,
+            data_name = 'test',
+            data_path = 'tes.sqlite3',
+            name = 'test',
+            description = None,
+            expectation = 'test',
+            entry_date = None,
+        )
+        assert False
+    except pydantic.ValidationError:
+        assert True
+
+

--- a/tests/unit/expectations/test_core.py
+++ b/tests/unit/expectations/test_core.py
@@ -4,7 +4,7 @@ from digital_land.expectations.core import (
     transform_df_first_column_into_set,
     config_parser,
     QueryRunner,
-    ExpectationResponse
+    ExpectationResponse,
 )
 
 
@@ -110,23 +110,22 @@ def test_config_parser():
 
     assert result == expected_dictionary
 
+
 def test_ExpectationResponse__init__fails_validation():
     try:
         ExpectationResponse(
-            expectation_input= {'test':'test1'},
-            result = True,
-            severity = 'invalid_string',
-            msg = 'Success',
-            details = None,
-            data_name = 'test',
-            data_path = 'tes.sqlite3',
-            name = 'test',
-            description = None,
-            expectation = 'test',
-            entry_date = None,
+            expectation_input={"test": "test1"},
+            result=True,
+            severity="invalid_string",
+            msg="Success",
+            details=None,
+            data_name="test",
+            data_path="tes.sqlite3",
+            name="test",
+            description=None,
+            expectation="test",
+            entry_date=None,
         )
         assert False
     except pydantic.ValidationError:
         assert True
-
-

--- a/tests/unit/expectations/test_expectations.py
+++ b/tests/unit/expectations/test_expectations.py
@@ -36,12 +36,12 @@ def test_check_database_has_expected_tables_Success():
         "old_entity",
     }
 
-    response = expect_database_to_have_set_of_tables(
+    result,msg,details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=True
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg is not None
 
 
 def test_check_database_has_expected_tables_Success_with_fme_false():
@@ -57,12 +57,12 @@ def test_check_database_has_expected_tables_Success_with_fme_false():
         "old_entity",
     }
 
-    response = expect_database_to_have_set_of_tables(
+    result,msg,details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=False
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg is not None
 
 
 def test_check_database_has_expected_tables_Fail():
@@ -78,16 +78,16 @@ def test_check_database_has_expected_tables_Fail():
         "issue",
         "old_entity",
     }
-    response = expect_database_to_have_set_of_tables(
+    result,msg,details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=True
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: difference between expected tables and found tables on the db see details"
     )
-    assert response.details == {
+    assert details == {
         "expected_tables": {
             "dataset_resource",
             "fact",
@@ -124,11 +124,11 @@ def test_check_database_has_expected_tables_Fail_with_fme_false():
         "old_entity",
     }
 
-    response = expect_database_to_have_set_of_tables(
+    result,msg,details= expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=False
     )
 
-    assert not response.result
+    assert not result
 
 
 def test_check_database_has_expected_tables_find_more_than_expected_fail():
@@ -143,11 +143,11 @@ def test_check_database_has_expected_tables_find_more_than_expected_fail():
         "old_entity",
     }
 
-    response = expect_database_to_have_set_of_tables(
+    result,msg,details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=True
     )
 
-    assert not response.result
+    assert not result
 
 
 def test_check_table_has_expected_columns_Success():
@@ -171,12 +171,12 @@ def test_check_table_has_expected_columns_Success():
         "prefix",
     }
 
-    response = expect_table_to_have_set_of_columns(
+    result,msg,details = expect_table_to_have_set_of_columns(
         query_runner, table_name=table_name, expected_columns_set=expected_column_set
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_table_has_expected_columns_Fail():
@@ -200,11 +200,11 @@ def test_check_table_has_expected_columns_Fail():
         "organisation_entity",
         "prefix",
     }
-    response = expect_table_to_have_set_of_columns(
+    result,msg,details = expect_table_to_have_set_of_columns(
         query_runner, table_name=table_name, expected_columns_set=expected_column_set
     )
 
-    assert not response.result
+    assert not result
 
 
 def test_check_table_has_expected_columns_fail_if_find_more_than_expected_Fail():
@@ -227,14 +227,14 @@ def test_check_table_has_expected_columns_fail_if_find_more_than_expected_Fail()
         "organisation_entity",
         "prefix",
     }
-    response = expect_table_to_have_set_of_columns(
+    result,msg,details = expect_table_to_have_set_of_columns(
         query_runner,
         table_name=table_name,
         expected_columns_set=expected_column_set,
         fail_if_found_more_than_expected=fail_if_found_more_than_expected,
     )
 
-    assert not response.result
+    assert not result
 
 
 def test_check_table_has_expected_columns_success_if_find_more_than_expected_Success():
@@ -258,15 +258,15 @@ def test_check_table_has_expected_columns_success_if_find_more_than_expected_Suc
         "organisation_entity",
         "prefix",
     }
-    response = expect_table_to_have_set_of_columns(
+    result,msg,details = expect_table_to_have_set_of_columns(
         query_runner,
         table_name=table_name,
         expected_columns_set=expected_column_set,
         fail_if_found_more_than_expected=fail_if_found_more_than_expected,
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_row_count_of_table_is_in_expected_range_Success():
@@ -275,15 +275,15 @@ def test_row_count_of_table_is_in_expected_range_Success():
     table_name = "entity"
     min_expected_row_count = 400
     max_expected_row_count = 500
-    response = expect_table_row_count_to_be_in_range(
+    result,msg,details = expect_table_row_count_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         min_expected_row_count=min_expected_row_count,
         max_expected_row_count=max_expected_row_count,
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_row_count_of_table_is_in_expected_range_Fail():
@@ -292,19 +292,19 @@ def test_row_count_of_table_is_in_expected_range_Fail():
     table_name = "entity"
     min_expected_row_count = 200
     max_expected_row_count = 300
-    response = expect_table_row_count_to_be_in_range(
+    result,msg,details = expect_table_row_count_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         min_expected_row_count=min_expected_row_count,
         max_expected_row_count=max_expected_row_count,
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: row count not in the expected range for table 'entity' see details"
     )
-    assert response.details == {
+    assert details == {
         "table": "entity",
         "counted_rows": 200,
         "min_expected": 200,
@@ -322,15 +322,15 @@ def test_row_count_grouped_by_field_Success2():
         {"lookup_value": "42114490", "min_row_count": 8, "max_row_count": 10},
     ]
 
-    response = expect_row_count_for_lookup_value_to_be_in_range(
+    result,msg,details = expect_row_count_for_lookup_value_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         field_name=field_name,
         count_ranges_per_value=dict_value_and_count_ranges,
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_row_count_grouped_by_field_Fail():
@@ -343,19 +343,19 @@ def test_row_count_grouped_by_field_Fail():
         {"lookup_value": "42114490", "min_row_count": 6, "max_row_count": 8},
     ]
 
-    response = expect_row_count_for_lookup_value_to_be_in_range(
+    result,msg,details = expect_row_count_for_lookup_value_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         field_name=field_name,
         count_ranges_per_value=dict_value_and_count_ranges,
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: table 'fact': one or more counts per lookup_value not in expected range see for more info see details"
     )
-    assert response.details == [
+    assert details == [
         {
             "lookup_value": "42114490",
             "min_row_count": 6,
@@ -383,7 +383,7 @@ def test_check_field_values_within_expected_set_of_values_No_unexpected_value():
         "description",
     }
 
-    response = expect_field_values_to_be_within_set(
+    result,msg,details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -391,8 +391,8 @@ def test_check_field_values_within_expected_set_of_values_No_unexpected_value():
         fail_if_not_found_entire_expected_set,
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_field_values_within_expected_set_of_values_One_unexpected_value():
@@ -412,7 +412,7 @@ def test_check_field_values_within_expected_set_of_values_One_unexpected_value()
         "description",
     }
 
-    response = expect_field_values_to_be_within_set(
+    result,msg,details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -420,12 +420,12 @@ def test_check_field_values_within_expected_set_of_values_One_unexpected_value()
         fail_if_not_found_entire_expected_set,
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: values for field 'field' on table 'fact' do not fit expected set criteria, see details"
     )
-    assert response.details == {
+    assert details == {
         "table": "fact",
         "expected_values": {
             "not_present_value",
@@ -473,7 +473,7 @@ def test_check_field_values_within_expected_set_of_values_Not_found_entire_expec
         "description",
     }
 
-    response = expect_field_values_to_be_within_set(
+    result,msg,details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -481,12 +481,12 @@ def test_check_field_values_within_expected_set_of_values_Not_found_entire_expec
         fail_if_not_found_entire_expected_set,
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: values for field 'field' on table 'fact' do not fit expected set criteria, see details"
     )
-    assert response.details == {
+    assert details == {
         "table": "fact",
         "expected_values": {
             "not_present_value",
@@ -533,7 +533,7 @@ def test_check_field_values_within_expected_set_of_values_Entire_expected_set_fo
         "description",
     }
 
-    response = expect_field_values_to_be_within_set(
+    result,msg,details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -541,8 +541,8 @@ def test_check_field_values_within_expected_set_of_values_Entire_expected_set_fo
         fail_if_not_found_entire_expected_set,
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_uniqueness_field_set_of_fields_True():
@@ -552,10 +552,10 @@ def test_check_uniqueness_field_set_of_fields_True():
     table_name = "fact"
     fields = ["fact"]
 
-    response = expect_values_for_field_to_be_unique(query_runner, table_name, fields)
+    result,msg,details = expect_values_for_field_to_be_unique(query_runner, table_name, fields)
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_uniqueness_field_set_of_fields_False():
@@ -565,14 +565,14 @@ def test_check_uniqueness_field_set_of_fields_False():
     table_name = "fact"
     fields = ["field", "entry_date"]
 
-    response = expect_values_for_field_to_be_unique(query_runner, table_name, fields)
+    result,msg,details = expect_values_for_field_to_be_unique(query_runner, table_name, fields)
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: duplicate values for the combined fields '['field', 'entry_date']' on table 'fact', see details"
     )
-    assert response.details == {
+    assert details == {
         "duplicates_found": [
             {
                 "field": "description",
@@ -612,12 +612,12 @@ def test_check_geo_shapes_are_valid_True():
     shape_field = "geometry"
     ref_fields = ["entity"]
 
-    response = expect_geoshapes_to_be_valid(
+    result,msg,details = expect_geoshapes_to_be_valid(
         query_runner, table_name, shape_field, ref_fields
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_geo_shapes_are_valid_False():
@@ -629,16 +629,16 @@ def test_check_geo_shapes_are_valid_False():
     shape_field = "geometry"
     ref_fields = ["entity"]
 
-    response = expect_geoshapes_to_be_valid(
+    result,msg,details = expect_geoshapes_to_be_valid(
         query_runner, table_name, shape_field, ref_fields
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: 1 invalid shapes found in field 'geometry' on table 'one_invalid_among_five', see details"
     )
-    assert response.details == {"invalid_shapes": [{"entity": 303443, "is_valid": 0}]}
+    assert details == {"invalid_shapes": [{"entity": 303443, "is_valid": 0}]}
 
 
 def test_check_json_values_for_key_within_expected_set_True():
@@ -650,12 +650,12 @@ def test_check_json_values_for_key_within_expected_set_True():
 
     expected_values_set = {"I", "II", "III", "II*"}
 
-    response = expect_values_for_a_key_stored_in_json_are_within_a_set(
+    result,msg,details = expect_values_for_a_key_stored_in_json_are_within_a_set(
         query_runner, table_name, field_name, json_key, expected_values_set, ref_fields
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_json_values_for_key_within_expected_set_False():
@@ -667,16 +667,16 @@ def test_check_json_values_for_key_within_expected_set_False():
 
     expected_values_set = {"I", "II", "III"}
 
-    response = expect_values_for_a_key_stored_in_json_are_within_a_set(
+    result,msg,details = expect_values_for_a_key_stored_in_json_are_within_a_set(
         query_runner, table_name, field_name, json_key, expected_values_set, ref_fields
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: found non-expected values for key 'listed-building-grade' in field 'json' on table 'entity', see details"
     )
-    assert response.details == {
+    assert details == {
         "non_expected_values": [
             {"entity": 42114490, "value_found_for_key": "II*"},
             {"entity": 42114499, "value_found_for_key": "II*"},
@@ -740,13 +740,13 @@ def test_check_json_values_for__not_found_key_False():
 
     expected_values_set = {"I", "II", "III", "II*"}
 
-    response = expect_values_for_a_key_stored_in_json_are_within_a_set(
+    result,msg,details = expect_values_for_a_key_stored_in_json_are_within_a_set(
         query_runner, table_name, field_name, json_key, expected_values_set, ref_fields
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: found non-expected values for key 'not-present-key' in field 'json' on table 'entity', see details"
     )
     # because in this case the details will bring to many rows we decided not to assert details content
@@ -764,12 +764,12 @@ def test_check_json_keys_are_within_Expected_keys_set_True():
         "notes",
     }
 
-    response = expect_keys_in_json_field_to_be_in_set_of_options(
+    result,msg,details = expect_keys_in_json_field_to_be_in_set_of_options(
         query_runner, table_name, field_name, expected_key_set, ref_fields
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_json_keys_are_within_Expected_keys_set_False():
@@ -779,13 +779,13 @@ def test_check_json_keys_are_within_Expected_keys_set_False():
     ref_fields = ["entity"]
     expected_key_set = {"listed-building-grade", "documentation-url", "description"}
 
-    response = expect_keys_in_json_field_to_be_in_set_of_options(
+    result,msg,details = expect_keys_in_json_field_to_be_in_set_of_options(
         query_runner, table_name, field_name, expected_key_set, ref_fields
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: found non-expected json keys in the field 'json' on table 'entity', see details"
     )
     # because in this case the details will bring ~450 rows we decided not to assert details content
@@ -799,7 +799,7 @@ def test_check_value_for_field_is_within_expected_range_True():
     max_expected_value = 1481085
     ref_fields = ["entity"]
 
-    response = expect_values_in_field_to_be_within_range(
+    result,msg,details = expect_values_in_field_to_be_within_range(
         query_runner,
         table_name,
         field_name,
@@ -808,8 +808,8 @@ def test_check_value_for_field_is_within_expected_range_True():
         ref_fields,
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_value_for_field_is_within_expected_range_False():
@@ -820,7 +820,7 @@ def test_check_value_for_field_is_within_expected_range_False():
     max_expected_value = 1300000
     ref_fields = ["entity"]
 
-    response = expect_values_in_field_to_be_within_range(
+    result,msg,details = expect_values_in_field_to_be_within_range(
         query_runner,
         table_name,
         field_name,
@@ -829,12 +829,12 @@ def test_check_value_for_field_is_within_expected_range_False():
         ref_fields,
     )
 
-    assert not response.result
+    assert not result
     assert (
-        response.msg
+        msg
         == "Fail: found 18 values out of the expected range for field 'reference' on table 'entity', see details"
     )
-    assert response.details == {
+    assert details == {
         "records_with_value_out_of_range": [
             {"entity": 42114935, "reference": "1303676"},
             {"entity": 42114936, "reference": "1303751"},
@@ -889,12 +889,12 @@ def test_check_custom_query_expectataion_True():
         },
     ]
 
-    response = expect_custom_query_result_to_be_as_predicted(
+    result,msg,details = expect_custom_query_result_to_be_as_predicted(
         query_runner, custom_query, expected_query_result
     )
 
-    assert response.result
-    assert response.msg == "Success: data quality as expected"
+    assert result
+    assert msg == "Success: data quality as expected"
 
 
 def test_check_custom_query_expectataion_Fail():
@@ -922,17 +922,15 @@ def test_check_custom_query_expectataion_Fail():
         },
     ]
 
-    response = expect_custom_query_result_to_be_as_predicted(
+    result,msg,details = expect_custom_query_result_to_be_as_predicted(
         query_runner, custom_query, expected_query_result
     )
 
-    print(response.details)
-
-    assert not response.result
+    assert not result
     assert (
-        response.msg == "Fail: result for custom query was not as expected, see details"
+        msg == "Fail: result for custom query was not as expected, see details"
     )
-    assert response.details == {
+    assert details == {
         "custom_query": "SELECT dataset, entity, typology, reference FROM entity WHERE reference IN (1090769,1090770,1090771,1090772)",
         "query_result": [
             {
@@ -995,7 +993,7 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_True():
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".org.uk"]
 
-    response = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1004,7 +1002,7 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_True():
         ref_fields,
     )
 
-    assert response.result
+    assert result
 
 
 def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False1():
@@ -1019,7 +1017,7 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False1(
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".irg.uk"]
 
-    response = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1028,8 +1026,8 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False1(
         ref_fields,
     )
 
-    assert not response.result
-    assert response.msg == "Fail: found 2 records with unexpected domains, see details"
+    assert not result
+    assert msg == "Fail: found 2 records with unexpected domains, see details"
 
 
 def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False2():
@@ -1044,7 +1042,7 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False2(
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".org.uk"]
 
-    response = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1053,8 +1051,8 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False2(
         ref_fields,
     )
 
-    assert not response.result
-    assert response.msg == "Fail: found 1 invalid URLs, see details"
+    assert not result
+    assert msg == "Fail: found 1 invalid URLs, see details"
 
 
 def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False3():
@@ -1075,7 +1073,7 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False3(
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".org.uk"]
 
-    response = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1084,8 +1082,8 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False3(
         ref_fields,
     )
 
-    assert not response.result
-    assert response.msg == "Fail: found 5 records with unexpected domains, see details"
+    assert not result
+    assert msg == "Fail: found 5 records with unexpected domains, see details"
 
 
 def test_build_entity_where_clause_where_text_values_are_contained():

--- a/tests/unit/expectations/test_expectations.py
+++ b/tests/unit/expectations/test_expectations.py
@@ -36,7 +36,7 @@ def test_check_database_has_expected_tables_Success():
         "old_entity",
     }
 
-    result,msg,details = expect_database_to_have_set_of_tables(
+    result, msg, details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=True
     )
 
@@ -57,7 +57,7 @@ def test_check_database_has_expected_tables_Success_with_fme_false():
         "old_entity",
     }
 
-    result,msg,details = expect_database_to_have_set_of_tables(
+    result, msg, details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=False
     )
 
@@ -78,7 +78,7 @@ def test_check_database_has_expected_tables_Fail():
         "issue",
         "old_entity",
     }
-    result,msg,details = expect_database_to_have_set_of_tables(
+    result, msg, details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=True
     )
 
@@ -124,7 +124,7 @@ def test_check_database_has_expected_tables_Fail_with_fme_false():
         "old_entity",
     }
 
-    result,msg,details= expect_database_to_have_set_of_tables(
+    result, msg, details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=False
     )
 
@@ -143,7 +143,7 @@ def test_check_database_has_expected_tables_find_more_than_expected_fail():
         "old_entity",
     }
 
-    result,msg,details = expect_database_to_have_set_of_tables(
+    result, msg, details = expect_database_to_have_set_of_tables(
         query_runner, expected_table_set, fail_if_found_more_than_expected=True
     )
 
@@ -171,7 +171,7 @@ def test_check_table_has_expected_columns_Success():
         "prefix",
     }
 
-    result,msg,details = expect_table_to_have_set_of_columns(
+    result, msg, details = expect_table_to_have_set_of_columns(
         query_runner, table_name=table_name, expected_columns_set=expected_column_set
     )
 
@@ -200,7 +200,7 @@ def test_check_table_has_expected_columns_Fail():
         "organisation_entity",
         "prefix",
     }
-    result,msg,details = expect_table_to_have_set_of_columns(
+    result, msg, details = expect_table_to_have_set_of_columns(
         query_runner, table_name=table_name, expected_columns_set=expected_column_set
     )
 
@@ -227,7 +227,7 @@ def test_check_table_has_expected_columns_fail_if_find_more_than_expected_Fail()
         "organisation_entity",
         "prefix",
     }
-    result,msg,details = expect_table_to_have_set_of_columns(
+    result, msg, details = expect_table_to_have_set_of_columns(
         query_runner,
         table_name=table_name,
         expected_columns_set=expected_column_set,
@@ -258,7 +258,7 @@ def test_check_table_has_expected_columns_success_if_find_more_than_expected_Suc
         "organisation_entity",
         "prefix",
     }
-    result,msg,details = expect_table_to_have_set_of_columns(
+    result, msg, details = expect_table_to_have_set_of_columns(
         query_runner,
         table_name=table_name,
         expected_columns_set=expected_column_set,
@@ -275,7 +275,7 @@ def test_row_count_of_table_is_in_expected_range_Success():
     table_name = "entity"
     min_expected_row_count = 400
     max_expected_row_count = 500
-    result,msg,details = expect_table_row_count_to_be_in_range(
+    result, msg, details = expect_table_row_count_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         min_expected_row_count=min_expected_row_count,
@@ -292,7 +292,7 @@ def test_row_count_of_table_is_in_expected_range_Fail():
     table_name = "entity"
     min_expected_row_count = 200
     max_expected_row_count = 300
-    result,msg,details = expect_table_row_count_to_be_in_range(
+    result, msg, details = expect_table_row_count_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         min_expected_row_count=min_expected_row_count,
@@ -322,7 +322,7 @@ def test_row_count_grouped_by_field_Success2():
         {"lookup_value": "42114490", "min_row_count": 8, "max_row_count": 10},
     ]
 
-    result,msg,details = expect_row_count_for_lookup_value_to_be_in_range(
+    result, msg, details = expect_row_count_for_lookup_value_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         field_name=field_name,
@@ -343,7 +343,7 @@ def test_row_count_grouped_by_field_Fail():
         {"lookup_value": "42114490", "min_row_count": 6, "max_row_count": 8},
     ]
 
-    result,msg,details = expect_row_count_for_lookup_value_to_be_in_range(
+    result, msg, details = expect_row_count_for_lookup_value_to_be_in_range(
         query_runner=query_runner,
         table_name=table_name,
         field_name=field_name,
@@ -383,7 +383,7 @@ def test_check_field_values_within_expected_set_of_values_No_unexpected_value():
         "description",
     }
 
-    result,msg,details = expect_field_values_to_be_within_set(
+    result, msg, details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -412,7 +412,7 @@ def test_check_field_values_within_expected_set_of_values_One_unexpected_value()
         "description",
     }
 
-    result,msg,details = expect_field_values_to_be_within_set(
+    result, msg, details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -473,7 +473,7 @@ def test_check_field_values_within_expected_set_of_values_Not_found_entire_expec
         "description",
     }
 
-    result,msg,details = expect_field_values_to_be_within_set(
+    result, msg, details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -533,7 +533,7 @@ def test_check_field_values_within_expected_set_of_values_Entire_expected_set_fo
         "description",
     }
 
-    result,msg,details = expect_field_values_to_be_within_set(
+    result, msg, details = expect_field_values_to_be_within_set(
         query_runner,
         table_name,
         field_name,
@@ -552,7 +552,9 @@ def test_check_uniqueness_field_set_of_fields_True():
     table_name = "fact"
     fields = ["fact"]
 
-    result,msg,details = expect_values_for_field_to_be_unique(query_runner, table_name, fields)
+    result, msg, details = expect_values_for_field_to_be_unique(
+        query_runner, table_name, fields
+    )
 
     assert result
     assert msg == "Success: data quality as expected"
@@ -565,7 +567,9 @@ def test_check_uniqueness_field_set_of_fields_False():
     table_name = "fact"
     fields = ["field", "entry_date"]
 
-    result,msg,details = expect_values_for_field_to_be_unique(query_runner, table_name, fields)
+    result, msg, details = expect_values_for_field_to_be_unique(
+        query_runner, table_name, fields
+    )
 
     assert not result
     assert (
@@ -612,7 +616,7 @@ def test_check_geo_shapes_are_valid_True():
     shape_field = "geometry"
     ref_fields = ["entity"]
 
-    result,msg,details = expect_geoshapes_to_be_valid(
+    result, msg, details = expect_geoshapes_to_be_valid(
         query_runner, table_name, shape_field, ref_fields
     )
 
@@ -629,7 +633,7 @@ def test_check_geo_shapes_are_valid_False():
     shape_field = "geometry"
     ref_fields = ["entity"]
 
-    result,msg,details = expect_geoshapes_to_be_valid(
+    result, msg, details = expect_geoshapes_to_be_valid(
         query_runner, table_name, shape_field, ref_fields
     )
 
@@ -650,7 +654,7 @@ def test_check_json_values_for_key_within_expected_set_True():
 
     expected_values_set = {"I", "II", "III", "II*"}
 
-    result,msg,details = expect_values_for_a_key_stored_in_json_are_within_a_set(
+    result, msg, details = expect_values_for_a_key_stored_in_json_are_within_a_set(
         query_runner, table_name, field_name, json_key, expected_values_set, ref_fields
     )
 
@@ -667,7 +671,7 @@ def test_check_json_values_for_key_within_expected_set_False():
 
     expected_values_set = {"I", "II", "III"}
 
-    result,msg,details = expect_values_for_a_key_stored_in_json_are_within_a_set(
+    result, msg, details = expect_values_for_a_key_stored_in_json_are_within_a_set(
         query_runner, table_name, field_name, json_key, expected_values_set, ref_fields
     )
 
@@ -740,7 +744,7 @@ def test_check_json_values_for__not_found_key_False():
 
     expected_values_set = {"I", "II", "III", "II*"}
 
-    result,msg,details = expect_values_for_a_key_stored_in_json_are_within_a_set(
+    result, msg, details = expect_values_for_a_key_stored_in_json_are_within_a_set(
         query_runner, table_name, field_name, json_key, expected_values_set, ref_fields
     )
 
@@ -764,7 +768,7 @@ def test_check_json_keys_are_within_Expected_keys_set_True():
         "notes",
     }
 
-    result,msg,details = expect_keys_in_json_field_to_be_in_set_of_options(
+    result, msg, details = expect_keys_in_json_field_to_be_in_set_of_options(
         query_runner, table_name, field_name, expected_key_set, ref_fields
     )
 
@@ -779,7 +783,7 @@ def test_check_json_keys_are_within_Expected_keys_set_False():
     ref_fields = ["entity"]
     expected_key_set = {"listed-building-grade", "documentation-url", "description"}
 
-    result,msg,details = expect_keys_in_json_field_to_be_in_set_of_options(
+    result, msg, details = expect_keys_in_json_field_to_be_in_set_of_options(
         query_runner, table_name, field_name, expected_key_set, ref_fields
     )
 
@@ -799,7 +803,7 @@ def test_check_value_for_field_is_within_expected_range_True():
     max_expected_value = 1481085
     ref_fields = ["entity"]
 
-    result,msg,details = expect_values_in_field_to_be_within_range(
+    result, msg, details = expect_values_in_field_to_be_within_range(
         query_runner,
         table_name,
         field_name,
@@ -820,7 +824,7 @@ def test_check_value_for_field_is_within_expected_range_False():
     max_expected_value = 1300000
     ref_fields = ["entity"]
 
-    result,msg,details = expect_values_in_field_to_be_within_range(
+    result, msg, details = expect_values_in_field_to_be_within_range(
         query_runner,
         table_name,
         field_name,
@@ -889,7 +893,7 @@ def test_check_custom_query_expectataion_True():
         },
     ]
 
-    result,msg,details = expect_custom_query_result_to_be_as_predicted(
+    result, msg, details = expect_custom_query_result_to_be_as_predicted(
         query_runner, custom_query, expected_query_result
     )
 
@@ -922,14 +926,12 @@ def test_check_custom_query_expectataion_Fail():
         },
     ]
 
-    result,msg,details = expect_custom_query_result_to_be_as_predicted(
+    result, msg, details = expect_custom_query_result_to_be_as_predicted(
         query_runner, custom_query, expected_query_result
     )
 
     assert not result
-    assert (
-        msg == "Fail: result for custom query was not as expected, see details"
-    )
+    assert msg == "Fail: result for custom query was not as expected, see details"
     assert details == {
         "custom_query": "SELECT dataset, entity, typology, reference FROM entity WHERE reference IN (1090769,1090770,1090771,1090772)",
         "query_result": [
@@ -993,7 +995,11 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_True():
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".org.uk"]
 
-    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    (
+        result,
+        msg,
+        details,
+    ) = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1017,7 +1023,11 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False1(
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".irg.uk"]
 
-    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    (
+        result,
+        msg,
+        details,
+    ) = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1042,7 +1052,11 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False2(
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".org.uk"]
 
-    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    (
+        result,
+        msg,
+        details,
+    ) = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,
@@ -1073,7 +1087,11 @@ def test_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings_False3(
     ref_fields = ["entity"]
     list_of_domain_endings = [".gov.uk", ".org.uk"]
 
-    result,msg,details = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
+    (
+        result,
+        msg,
+        details,
+    ) = expect_urls_stored_for_a_key_in_json_to_end_in_expected_domain_endings(
         custom_query_runner,
         table_name,
         field_name,

--- a/tests/unit/expectations/test_suite.py
+++ b/tests/unit/expectations/test_suite.py
@@ -1,0 +1,71 @@
+import pytest
+import logging
+from digital_land.expectations.suite import DatasetExpectationSuite
+from digital_land.expectations.core import DataQualityException
+
+@pytest.fixture
+def test_expectation_function():
+    def simple_expectation(number_1,number_2,**kwargs):
+        result = number_1 > number_2
+        if result:
+            msg = 'Success'
+        else:
+            msg= 'Fail'
+        
+        details = {'number_1':number_1,'number_2':number_2}
+        return result,msg,details
+    
+    return simple_expectation
+
+def test_run_expectation_success(mocker,test_expectation_function):
+    # set up mocking
+    class MockExpectationFunctions:
+        def __init__(self,test_expectation_function):
+            self.test_expectation_function = test_expectation_function
+    
+    mocker.patch('digital_land.expectations.suite.expectations', MockExpectationFunctions(test_expectation_function=test_expectation_function))
+    # set up class inputs
+    results_file_path = 'result.csv'
+    data_path = 'test/data.sqlite3'
+    expectation_suite_yaml = 'expectations.yaml'
+
+    # set up function input
+    expectation = {'severity':'critical','name':'number 1 is bigger than number 2','expectation':'test_expectation_function','number_1':5,'number_2':2}
+    
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    response = suite.run_expectation(expectation)
+    assert response.result
+
+def test_act_on_critical_error_raises_error():
+    #set uputs
+    results_file_path='results/results.csv'
+    data_path='test.sqlite3'
+    expectation_suite_yaml='expectations.yaml'
+
+    # create suite and save responses
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+
+    try:
+        suite.act_on_critical_error(2)
+        assert False
+    except DataQualityException:
+        assert True
+
+def test_act_on_critical_error_does_not_rais_error():
+    #set uputs
+    results_file_path='results/results.csv'
+    data_path='test.sqlite3'
+    expectation_suite_yaml='expectations.yaml'
+
+    # create suite and save responses
+    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+
+    try:
+        suite.act_on_critical_error(0)
+        assert True
+    except DataQualityException:
+        assert False
+
+
+
+

--- a/tests/unit/expectations/test_suite.py
+++ b/tests/unit/expectations/test_suite.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 from digital_land.expectations.suite import DatasetExpectationSuite
 from digital_land.expectations.core import DataQualityException
 

--- a/tests/unit/expectations/test_suite.py
+++ b/tests/unit/expectations/test_suite.py
@@ -3,47 +3,67 @@ import logging
 from digital_land.expectations.suite import DatasetExpectationSuite
 from digital_land.expectations.core import DataQualityException
 
+
 @pytest.fixture
 def test_expectation_function():
-    def simple_expectation(number_1,number_2,**kwargs):
+    def simple_expectation(number_1, number_2, **kwargs):
         result = number_1 > number_2
         if result:
-            msg = 'Success'
+            msg = "Success"
         else:
-            msg= 'Fail'
-        
-        details = {'number_1':number_1,'number_2':number_2}
-        return result,msg,details
-    
+            msg = "Fail"
+
+        details = {"number_1": number_1, "number_2": number_2}
+        return result, msg, details
+
     return simple_expectation
 
-def test_run_expectation_success(mocker,test_expectation_function):
+
+def test_run_expectation_success(mocker, test_expectation_function):
     # set up mocking
     class MockExpectationFunctions:
-        def __init__(self,test_expectation_function):
+        def __init__(self, test_expectation_function):
             self.test_expectation_function = test_expectation_function
-    
-    mocker.patch('digital_land.expectations.suite.expectations', MockExpectationFunctions(test_expectation_function=test_expectation_function))
+
+    mocker.patch(
+        "digital_land.expectations.suite.expectations",
+        MockExpectationFunctions(test_expectation_function=test_expectation_function),
+    )
     # set up class inputs
-    results_file_path = 'result.csv'
-    data_path = 'test/data.sqlite3'
-    expectation_suite_yaml = 'expectations.yaml'
+    results_file_path = "result.csv"
+    data_path = "test/data.sqlite3"
+    expectation_suite_yaml = "expectations.yaml"
 
     # set up function input
-    expectation = {'severity':'critical','name':'number 1 is bigger than number 2','expectation':'test_expectation_function','number_1':5,'number_2':2}
-    
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    expectation = {
+        "severity": "critical",
+        "name": "number 1 is bigger than number 2",
+        "expectation": "test_expectation_function",
+        "number_1": 5,
+        "number_2": 2,
+    }
+
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
     response = suite.run_expectation(expectation)
     assert response.result
 
+
 def test_act_on_critical_error_raises_error():
-    #set uputs
-    results_file_path='results/results.csv'
-    data_path='test.sqlite3'
-    expectation_suite_yaml='expectations.yaml'
+    # set uputs
+    results_file_path = "results/results.csv"
+    data_path = "test.sqlite3"
+    expectation_suite_yaml = "expectations.yaml"
 
     # create suite and save responses
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
 
     try:
         suite.act_on_critical_error(2)
@@ -51,21 +71,22 @@ def test_act_on_critical_error_raises_error():
     except DataQualityException:
         assert True
 
+
 def test_act_on_critical_error_does_not_rais_error():
-    #set uputs
-    results_file_path='results/results.csv'
-    data_path='test.sqlite3'
-    expectation_suite_yaml='expectations.yaml'
+    # set uputs
+    results_file_path = "results/results.csv"
+    data_path = "test.sqlite3"
+    expectation_suite_yaml = "expectations.yaml"
 
     # create suite and save responses
-    suite = DatasetExpectationSuite(results_file_path=results_file_path,data_path=data_path,expectation_suite_yaml=expectation_suite_yaml)
+    suite = DatasetExpectationSuite(
+        results_file_path=results_file_path,
+        data_path=data_path,
+        expectation_suite_yaml=expectation_suite_yaml,
+    )
 
     try:
         suite.act_on_critical_error(0)
         assert True
     except DataQualityException:
         assert False
-
-
-
-


### PR DESCRIPTION
What?
- refactor code to simplify burden on creating new expectations
- response uses enum for severity based on severity csv, could be replaced in the future to get values from csv

Why?
- severity should align across isues and expectations
- don;t want to change all functions when we change what is required in the expectation suite