### PR TITLE
log SSL error in logs rather than running without SSL

### DIFF
--- a/digital_land/collect.py
+++ b/digital_land/collect.py
@@ -76,10 +76,8 @@ class Collector:
                 timeout=120,
                 verify=verify_ssl,
             )
-        except requests.exceptions.SSLError:
-            logging.warning("Retrying without certificate validation due to SSLError")
-            return self.get(url, log, False)
         except (
+            requests.exceptions.SSLError,
             requests.ConnectionError,
             requests.HTTPError,
             requests.Timeout,

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -6,7 +6,6 @@ from datetime import datetime, timedelta
 
 import pytest
 import responses
-import requests
 
 from digital_land.collect import Collector, FetchStatus
 
@@ -71,24 +70,6 @@ def test_hash_failure(collector, prepared_response):
     status = collector.fetch("http://some.url", endpoint="http://other.url")
 
     assert status == FetchStatus.HASH_FAILURE
-
-# removed as We no longer retry for SSL, this test did not fully test SSL
-# only tested that function was run twice, unfortunately it didn't test that
-# the SSL disbaled function was working correctly
-# @responses.activate
-# def test_ssl_bad_cert(collector):
-#     url = "https://some.url.with.ssl.error"
-#     responses.add(responses.GET, url, body=requests.exceptions.SSLError())
-
-#     # Allow the request to work the second time. Unfortunately there is no
-#     # simple way to check that verify=False is passed to reqests.get
-#     responses.add(responses.GET, url, body="some data")
-
-#     status = collector.fetch(url)
-
-#     log = read_log(collector, url)
-#     assert status == FetchStatus.OK
-#     assert not log.get("ssl-verify", True)
 
 
 def read_log(collector, url):

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -72,21 +72,23 @@ def test_hash_failure(collector, prepared_response):
 
     assert status == FetchStatus.HASH_FAILURE
 
+# removed as We no longer retry for SSL, this test did not fully test SSL
+# only tested that function was run twice, unfortunately it didn't test that
+# the SSL disbaled function was working correctly
+# @responses.activate
+# def test_ssl_bad_cert(collector):
+#     url = "https://some.url.with.ssl.error"
+#     responses.add(responses.GET, url, body=requests.exceptions.SSLError())
 
-@responses.activate
-def test_ssl_bad_cert(collector):
-    url = "https://some.url.with.ssl.error"
-    responses.add(responses.GET, url, body=requests.exceptions.SSLError())
+#     # Allow the request to work the second time. Unfortunately there is no
+#     # simple way to check that verify=False is passed to reqests.get
+#     responses.add(responses.GET, url, body="some data")
 
-    # Allow the request to work the second time. Unfortunately there is no
-    # simple way to check that verify=False is passed to reqests.get
-    responses.add(responses.GET, url, body="some data")
+#     status = collector.fetch(url)
 
-    status = collector.fetch(url)
-
-    log = read_log(collector, url)
-    assert status == FetchStatus.OK
-    assert not log.get("ssl-verify", True)
+#     log = read_log(collector, url)
+#     assert status == FetchStatus.OK
+#     assert not log.get("ssl-verify", True)
 
 
 def read_log(collector, url):


### PR DESCRIPTION
What?
Change the behaviour when handling SSL error to log the error rather than using a recursive function to turn off SSL
Why?
The recursive function was raising an error as the package no longer supports disabling SSL, given that this could be considered a security risk it seems best to turn off for now. it records SSL error the same as any others. a link for a workaround is:
https://stackoverflow.com/questions/71603314/ssl-error-unsafe-legacy-renegotiation-disabled