### PR TITLE
Sniff coordinates in a MultiLineString

### DIFF
--- a/digital_land/datatype/wkt.py
+++ b/digital_land/datatype/wkt.py
@@ -64,8 +64,12 @@ def parse_wkt(value):
         first_point = geometry.coords[0]
     elif geometry.geom_type in ["Polygon"]:
         first_point = geometry.exterior.coords[0]
-    else:
+    elif geometry.geom_type in ["MultiPolygon"]:
         first_point = geometry.geoms[0].exterior.coords[0]
+    elif geometry.geom_type in ["MultiLineString"]:
+        first_point = geometry.geoms[0].coords[0]
+    else:
+        return None, "Unexpected geom type"
 
     x, y = first_point[:2]
 


### PR DESCRIPTION
Fail more gracefully on Newcastle's article 4 directions data which contains a MultiLineString.

The code now flags geometries beyond point, line and polygons as being invalid when testing coordinates, but I think they would similarly raise an exception with the old code anyway. 