### PR TITLE
Empty geometry column fix

### DIFF
--- a/digital_land/phase/map.py
+++ b/digital_land/phase/map.py
@@ -73,7 +73,10 @@ class MapPhase(Phase):
                 if headers[header] == "IGNORE":
                     continue
 
-                o[headers[header]] = row.get(header, "")
+                value = row.get(header)
+
+                if value is not None and value != "":
+                    o[headers[header]] = value
 
             for header in self.normalised_fieldnames.values():
                 if header not in o:

--- a/tests/unit/test_map.py
+++ b/tests/unit/test_map.py
@@ -37,3 +37,41 @@ def test_map_headers_column_clash():
     m = MapPhase(["One"], {"une": "One", "ein": "One"})
     output = TestPipeline(m, "une,ein\r\n1,2\r\n")
     assert output == "One\r\n1\r\n"
+
+
+def test_map_empty_geometry_column():
+    m = MapPhase(
+        [
+            "categories",
+            "conservation-area",
+            "documentation-url",
+            "end-date",
+            "entity",
+            "entry-date",
+            "geometry",
+            "legislation",
+            "name",
+            "notes",
+            "organisation",
+            "point",
+            "prefix",
+            "reference",
+            "start-date",
+        ],
+        {
+            "wkt": "geometry",
+            "documenturl": "documentation-url",
+            "url": "documentation-url",
+        },
+    )
+    output = TestPipeline(
+        m,
+        "categories,conservation-area,documentation-url,end-date,entity,"
+        "entry-date,WKT,legislation,name,notes,organisation,point,prefix,"
+        "reference,start-date,geometry\r\n,,,,,,MULTIPOLYGON(),,,,,,,,,,\r\n",
+    )
+    assert (
+        output == "categories,conservation-area,documentation-url,end-date,entity,"
+        "entry-date,geometry,legislation,name,notes,organisation,point,prefix,"
+        "reference,start-date\r\n,,,,,,MULTIPOLYGON(),,,,,,,,\r\n"
+    )


### PR DESCRIPTION
Card linked: https://trello.com/c/xA5vTiKf/312-handle-empty-geometry-column

Southwark has added an empty geometry column in their data.
While processing it in the phase/map file, the data looks something like ('WKT': 'Multipolygon()','geometry':'')
Currently when assigning data first the geometry column is loaded with wkt data and then it is wiped off when the empty geometry column is processed.

This PR modifies the assignment operation and check for data being empty before it is assigned. Hence it retains the geometry loaded by the wkt column.

The test adds an empty geometry column and checks if the fix has retained the geometry data.
 