### PR TITLE
Raising missing organisation issue during pipeline processing

### DIFF
--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -193,7 +193,7 @@ def pipeline_run(
             fields=specification.schema_field[schema],
             migrations=pipeline.migrations(),
         ),
-        OrganisationPhase(organisation=organisation),
+        OrganisationPhase(organisation=organisation, issue_log=issue_log),
         FieldPrunePhase(fields=specification.current_fieldnames(schema)),
         EntityReferencePhase(
             dataset=dataset,

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -193,7 +193,7 @@ def pipeline_run(
             fields=specification.schema_field[schema],
             migrations=pipeline.migrations(),
         ),
-        OrganisationPhase(organisation=organisation, issue_log=issue_log),
+        OrganisationPhase(organisation=organisation, issues=issue_log),
         FieldPrunePhase(fields=specification.current_fieldnames(schema)),
         EntityReferencePhase(
             dataset=dataset,
@@ -654,7 +654,7 @@ def get_resource_unidentified_lookups(
             fields=specification.schema_field[schema],
             migrations=pipeline.migrations(),
         ),
-        OrganisationPhase(organisation=organisation),
+        OrganisationPhase(organisation=organisation, issues=issue_log),
         FieldPrunePhase(fields=specification.current_fieldnames(schema)),
         EntityReferencePhase(
             dataset=dataset,

--- a/digital_land/phase/organisation.py
+++ b/digital_land/phase/organisation.py
@@ -18,9 +18,10 @@ class OrganisationPhase(Phase):
                 self.issues.line_number = block["line-number"]
                 self.issues.entry_number = block["entry-number"]
 
+            organisation_value = row["organisation"]
             row["organisation"] = self.organisation.lookup(row["organisation"])
             if not row["organisation"]:
                 self.issues.log_issue(
-                    "organisation", "missing organisation", row["organisation"]
+                    "organisation", "invalid organisation", organisation_value
                 )
             yield block

--- a/digital_land/phase/organisation.py
+++ b/digital_land/phase/organisation.py
@@ -6,7 +6,7 @@ class OrganisationPhase(Phase):
     lookup the organisation
     """
 
-    def __init__(self, issues=None, organisation={}):
+    def __init__(self, organisation={}, issues=None):
         self.organisation = organisation
         self.issues = issues
 

--- a/digital_land/phase/organisation.py
+++ b/digital_land/phase/organisation.py
@@ -6,11 +6,21 @@ class OrganisationPhase(Phase):
     lookup the organisation
     """
 
-    def __init__(self, organisation={}):
+    def __init__(self, issues=None, organisation={}):
         self.organisation = organisation
+        self.issues = issues
 
     def process(self, stream):
         for block in stream:
             row = block["row"]
+            if self.issues:
+                self.issues.resource = block["resource"]
+                self.issues.line_number = block["line-number"]
+                self.issues.entry_number = block["entry-number"]
+
             row["organisation"] = self.organisation.lookup(row["organisation"])
+            if not row["organisation"]:
+                self.issues.log_issue(
+                    "organisation", "missing organisation", row["organisation"]
+                )
             yield block

--- a/tests/unit/phase/test_organisation.py
+++ b/tests/unit/phase/test_organisation.py
@@ -1,12 +1,16 @@
-from digital_land.organisation import Organisation
 from digital_land.phase.organisation import OrganisationPhase
 from digital_land.log import IssueLog
+from unittest.mock import Mock
 
 
-def test_process_with_valid_organisation():
-    organisation = Organisation(
-        organisation_path="tests/data/listed-building/organisation.csv"
-    )
+def test_process_with_valid_organisation(mocker):
+    mock_organisation = Mock()
+
+    # Mock the `lookup` method to return a predefined value
+    mock_organisation.lookup.return_value = "local-authority-eng:LBH"
+
+    mocker.patch("digital_land.phase.organisation", return_value=mock_organisation)
+
     input_stream = [
         {
             "row": {
@@ -15,15 +19,20 @@ def test_process_with_valid_organisation():
         }
     ]
 
-    organisationPhase = OrganisationPhase(organisation=organisation, issues=None)
+    organisationPhase = OrganisationPhase(organisation=mock_organisation, issues=None)
     output = [block for block in organisationPhase.process(input_stream)]
+    assert not organisationPhase.issues
     assert output[0]["row"]["organisation"] == "local-authority-eng:LBH"
 
 
-def test_process_with_invalid_organisation():
-    organisation = Organisation(
-        organisation_path="tests/data/listed-building/organisation.csv"
-    )
+def test_process_with_invalid_organisation(mocker):
+    mock_organisation = Mock()
+
+    # Mock the `lookup` method to return a predefined value
+    mock_organisation.lookup.return_value = ""
+
+    mocker.patch("digital_land.phase.organisation", return_value=mock_organisation)
+
     issues = IssueLog(dataset="brownfield-land", resource="1")
     input_stream = [
         {
@@ -35,6 +44,7 @@ def test_process_with_invalid_organisation():
             "entry-number": 2,
         }
     ]
-    organisationPhase = OrganisationPhase(organisation=organisation, issues=issues)
+    organisationPhase = OrganisationPhase(organisation=mock_organisation, issues=issues)
     output = [block for block in organisationPhase.process(input_stream)]
+    assert organisationPhase.issues
     assert output[0]["row"]["organisation"] == ""

--- a/tests/unit/phase/test_organisation.py
+++ b/tests/unit/phase/test_organisation.py
@@ -1,0 +1,40 @@
+from digital_land.organisation import Organisation
+from digital_land.phase.organisation import OrganisationPhase
+from digital_land.log import IssueLog
+
+
+def test_process_with_valid_organisation():
+    organisation = Organisation(
+        organisation_path="tests/data/listed-building/organisation.csv"
+    )
+    input_stream = [
+        {
+            "row": {
+                "organisation": "http://opendatacommunities.org/id/london-borough-council/lambeth",
+            }
+        }
+    ]
+
+    organisationPhase = OrganisationPhase(organisation=organisation, issues=None)
+    output = [block for block in organisationPhase.process(input_stream)]
+    assert output[0]["row"]["organisation"] == "local-authority-eng:LBH"
+
+
+def test_process_with_invalid_organisation():
+    organisation = Organisation(
+        organisation_path="tests/data/listed-building/organisation.csv"
+    )
+    issues = IssueLog(dataset="brownfield-land", resource="1")
+    input_stream = [
+        {
+            "row": {
+                "organisation": "http://open datacommunities.org/not_a_valid_organisation",
+            },
+            "resource": "1",
+            "line-number": 1,
+            "entry-number": 2,
+        }
+    ]
+    organisationPhase = OrganisationPhase(organisation=organisation, issues=issues)
+    output = [block for block in organisationPhase.process(input_stream)]
+    assert output[0]["row"]["organisation"] == ""

--- a/tests/unit/test_organisation.py
+++ b/tests/unit/test_organisation.py
@@ -1,4 +1,6 @@
 from digital_land.organisation import Organisation
+from digital_land.phase.organisation import OrganisationPhase
+from digital_land.log import IssueLog
 
 
 def test_organisation_lookup():
@@ -45,4 +47,41 @@ def test_organisation_lookup():
     )
 
     assert organisation.lookup("E07000068") == "local-authority-eng:BRW"
+
+
+def test_process_with_valid_organisation():
+    organisation = Organisation(
+        organisation_path="tests/data/listed-building/organisation.csv"
+    )
     assert organisation.lookup("Lambeth") == "local-authority-eng:LBH"
+    input_stream = [
+        {
+            "row": {
+                "organisation": "Lambeth",
+            }
+        }
+    ]
+    organisationPhase = OrganisationPhase(issues=None, organisation=organisation)
+    output = [block for block in organisationPhase.process(input_stream)]
+    assert output[0]["row"]["organisation"] == "local-authority-eng:LBH"
+
+
+def test_process_with_missing_organisation():
+    organisation = Organisation(
+        organisation_path="tests/data/listed-building/organisation.csv"
+    )
+    assert organisation.lookup("Borchester") == ""
+    issues = IssueLog(dataset="brownfield-land", resource="1")
+    input_stream = [
+        {
+            "row": {
+                "organisation": "Borchester",
+            },
+            "resource": "1",
+            "line-number": 1,
+            "entry-number": 2,
+        }
+    ]
+    organisationPhase = OrganisationPhase(issues=issues, organisation=organisation)
+    output = [block for block in organisationPhase.process(input_stream)]
+    assert output[0]["row"]["organisation"] == ""

--- a/tests/unit/test_organisation.py
+++ b/tests/unit/test_organisation.py
@@ -61,7 +61,7 @@ def test_process_with_valid_organisation():
             }
         }
     ]
-    organisationPhase = OrganisationPhase(issues=None, organisation=organisation)
+    organisationPhase = OrganisationPhase(organisation=organisation, issues=None)
     output = [block for block in organisationPhase.process(input_stream)]
     assert output[0]["row"]["organisation"] == "local-authority-eng:LBH"
 
@@ -82,6 +82,6 @@ def test_process_with_missing_organisation():
             "entry-number": 2,
         }
     ]
-    organisationPhase = OrganisationPhase(issues=issues, organisation=organisation)
+    organisationPhase = OrganisationPhase(organisation=organisation, issues=issues)
     output = [block for block in organisationPhase.process(input_stream)]
     assert output[0]["row"]["organisation"] == ""

--- a/tests/unit/test_organisation.py
+++ b/tests/unit/test_organisation.py
@@ -45,3 +45,4 @@ def test_organisation_lookup():
     )
 
     assert organisation.lookup("E07000068") == "local-authority-eng:BRW"
+    assert organisation.lookup("Lambeth") == "local-authority-eng:LBH"

--- a/tests/unit/test_organisation.py
+++ b/tests/unit/test_organisation.py
@@ -1,6 +1,4 @@
 from digital_land.organisation import Organisation
-from digital_land.phase.organisation import OrganisationPhase
-from digital_land.log import IssueLog
 
 
 def test_organisation_lookup():
@@ -47,41 +45,3 @@ def test_organisation_lookup():
     )
 
     assert organisation.lookup("E07000068") == "local-authority-eng:BRW"
-
-
-def test_process_with_valid_organisation():
-    organisation = Organisation(
-        organisation_path="tests/data/listed-building/organisation.csv"
-    )
-    assert organisation.lookup("Lambeth") == "local-authority-eng:LBH"
-    input_stream = [
-        {
-            "row": {
-                "organisation": "Lambeth",
-            }
-        }
-    ]
-    organisationPhase = OrganisationPhase(organisation=organisation, issues=None)
-    output = [block for block in organisationPhase.process(input_stream)]
-    assert output[0]["row"]["organisation"] == "local-authority-eng:LBH"
-
-
-def test_process_with_missing_organisation():
-    organisation = Organisation(
-        organisation_path="tests/data/listed-building/organisation.csv"
-    )
-    assert organisation.lookup("Borchester") == ""
-    issues = IssueLog(dataset="brownfield-land", resource="1")
-    input_stream = [
-        {
-            "row": {
-                "organisation": "Borchester",
-            },
-            "resource": "1",
-            "line-number": 1,
-            "entry-number": 2,
-        }
-    ]
-    organisationPhase = OrganisationPhase(organisation=organisation, issues=issues)
-    output = [block for block in organisationPhase.process(input_stream)]
-    assert output[0]["row"]["organisation"] == ""


### PR DESCRIPTION
Reference ticket: https://trello.com/c/M1W1kelh/447-raising-an-issue-for-missing-organisation-at-organisation-phase-itself

During the processing of an endpoint, we have no means to know if we encounter a Missing Organisation issue. Adding this to the issues list raised.