### PR TITLE
Replace underscores in column names with hyphens

### DIFF
--- a/digital_land/phase/map.py
+++ b/digital_land/phase/map.py
@@ -6,8 +6,13 @@ from .phase import Phase
 normalise_pattern = re.compile(r"[^a-z0-9-_]")
 
 
+def replace_underscores(name: str):
+    return name.replace("_", "-")
+
+
 def normalise(name):
-    return re.sub(normalise_pattern, "", name.lower())
+    new_name = replace_underscores(name)
+    return re.sub(normalise_pattern, "", new_name.lower())
 
 
 class MapPhase(Phase):
@@ -18,7 +23,9 @@ class MapPhase(Phase):
 
     def __init__(self, fieldnames, columns={}, log=None):
         self.columns = columns
-        self.normalised_fieldnames = {normalise(f): f for f in fieldnames}
+        self.normalised_fieldnames = {
+            normalise(f): replace_underscores(f) for f in fieldnames
+        }
         if not log:
             log = ColumnFieldLog()
         self.log = log

--- a/digital_land/phase/map.py
+++ b/digital_land/phase/map.py
@@ -6,12 +6,8 @@ from .phase import Phase
 normalise_pattern = re.compile(r"[^a-z0-9-_]")
 
 
-def replace_underscores(name: str):
-    return name.replace("_", "-")
-
-
 def normalise(name):
-    new_name = replace_underscores(name)
+    new_name = name.replace("_", "-")
     return re.sub(normalise_pattern, "", new_name.lower())
 
 
@@ -23,9 +19,7 @@ class MapPhase(Phase):
 
     def __init__(self, fieldnames, columns={}, log=None):
         self.columns = columns
-        self.normalised_fieldnames = {
-            normalise(f): replace_underscores(f) for f in fieldnames
-        }
+        self.normalised_fieldnames = {normalise(f): f for f in fieldnames}
         if not log:
             log = ColumnFieldLog()
         self.log = log

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -56,7 +56,7 @@ def get_test_column_csv_data_with_resource_endpoint_clash_ep_first(
             "REF",
             "REF",
         ],
-        "field": ["name", "ep_ref", "res_ref"],
+        "field": ["name", "ep-ref", "res-ref"],
     }
 
 
@@ -85,7 +85,7 @@ def get_test_column_csv_data_with_resource_endpoint_clash_res_first(
             "REF",
             "REF",
         ],
-        "field": ["name", "res_ref", "ep_ref"],
+        "field": ["name", "res-ref", "ep-ref"],
     }
 
 
@@ -240,7 +240,7 @@ def test_columns_when_csv_contains_clashing_entries_res_first(tmp_path):
 
     # -- Asert --
     assert columns["name"] == "name"
-    assert columns["ref"] == "res_ref"
+    assert columns["ref"] == "res-ref"
     assert "ep_ref" not in columns
 
 
@@ -275,7 +275,7 @@ def test_columns_when_csv_contains_clashing_entries_ep_first(tmp_path):
 
     # -- Asert --
     assert columns["name"] == "name"
-    assert columns["ref"] == "res_ref"
+    assert columns["ref"] == "res-ref"
     assert "ep_ref" not in columns
 
 

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -24,8 +24,8 @@ def get_test_column_csv_data_with_resources_and_endpoints(
         ],
         "field": [
             "name",
-            "res_field_one",
-            "ep_field_one",
+            "res-field-one",
+            "ep-field-one",
         ],
     }
 
@@ -131,8 +131,8 @@ def test_load_column_when_csv_contains_endpoints_and_resources(tmp_path):
     assert test_endpoint in column_keys
 
     assert {"name": "name"} in column_values
-    assert {"objectid": "res_field_one"} in column_values
-    assert {"dummy_fiel": "ep_field_one"} in column_values
+    assert {"objectid": "res-field-one"} in column_values
+    assert {"dummy-fiel": "ep-field-one"} in column_values
 
 
 def test_load_concat_when_csv_contains_endpoints_and_resources(tmp_path):
@@ -205,8 +205,8 @@ def test_columns_when_csv_contains_endpoints_and_resources(tmp_path):
 
     # -- Asert --
     assert columns["name"] == "name"
-    assert columns["objectid"] == "res_field_one"
-    assert columns["dummy_fiel"] == "ep_field_one"
+    assert columns["objectid"] == "res-field-one"
+    assert columns["dummy-fiel"] == "ep-field-one"
 
 
 def test_columns_when_csv_contains_clashing_entries_res_first(tmp_path):

--- a/tests/unit/phase/test_map.py
+++ b/tests/unit/phase/test_map.py
@@ -6,7 +6,7 @@ from digital_land.pipeline import run_pipeline
 from digital_land.phase.load import LoadPhase
 from digital_land.phase.parse import ParsePhase
 from digital_land.phase.map import MapPhase
-from digital_land.phase.map import normalise as map_normalise
+from digital_land.phase.map import normalise
 from digital_land.phase.save import SavePhase
 
 
@@ -89,7 +89,7 @@ def test_map_empty_geometry_column():
     ],
 )
 def test_map_normalize_removes_underscores(column_name, expected):
-    actual = map_normalise(column_name)
+    actual = normalise(column_name)
 
     assert actual == expected
 

--- a/tests/unit/test_map.py
+++ b/tests/unit/test_map.py
@@ -77,7 +77,7 @@ def test_map_empty_geometry_column():
     )
 
 
-def test_map_underscores_to_hyphens_not_in_specification():
+def test_map_column_names_with_underscores_when_column_not_in_specification():
     """
     This tests for successful mapping of resource columns not
     present in the specification schema fields
@@ -96,7 +96,7 @@ def test_map_underscores_to_hyphens_not_in_specification():
     )
 
 
-def test_map_underscores_to_hyphens_in_specification():
+def test_map_column_names_with_underscores_when_column_in_specification():
     """
     This tests for successful mapping of resource columns that are
     present in the specification schema fields

--- a/tests/unit/test_map.py
+++ b/tests/unit/test_map.py
@@ -75,3 +75,46 @@ def test_map_empty_geometry_column():
         "entry-date,geometry,legislation,name,notes,organisation,point,prefix,"
         "reference,start-date\r\n,,,,,,MULTIPOLYGON(),,,,,,,,\r\n"
     )
+
+
+def test_map_underscores_to_hyphens_not_in_specification():
+    """
+    This tests for successful mapping of resource columns not
+    present in the specification schema fields
+    :return:
+    """
+    fieldnames = ["Organisation_Label", "PermissionDate", "SiteNameAddress"]
+    columns = {"address": "SiteNameAddress", "ownership": "OwnershipStatus"}
+
+    m = MapPhase(fieldnames, columns)
+    output = TestPipeline(
+        m, "Organisation_Label,PermissionDate\r\ncol-1-val,col-2-val\r\n"
+    )
+    assert (
+        output
+        == "Organisation-Label,PermissionDate,SiteNameAddress\r\ncol-1-val,col-2-val,\r\n"
+    )
+
+
+def test_map_underscores_to_hyphens_in_specification():
+    """
+    This tests for successful mapping of resource columns that are
+    present in the specification schema fields
+    :return:
+    """
+    fieldnames = ["Organisation_Label", "end_date", "SiteNameAddress"]
+    columns = {
+        "organisation-label": "Organisation-Label",
+        "end-date": "end-date",
+        "ownership": "OwnershipStatus",
+    }
+
+    m = MapPhase(fieldnames, columns)
+    output = TestPipeline(
+        m, "Organisation_Label,end_date,SiteNameAddress\r\ncol-1-val,col-2-val,\r\n"
+    )
+
+    assert (
+        output
+        == "Organisation-Label,SiteNameAddress,end-date\r\ncol-1-val,,col-2-val\r\n"
+    )


### PR DESCRIPTION
made changes to the MapPhase to perform column name transform (underscore to hyphen) without the need for manual intervention