### PR TITLE
fix/shapely_deprecation_warning

### DIFF
--- a/digital_land/phase/combine.py
+++ b/digital_land/phase/combine.py
@@ -10,7 +10,7 @@ import shapely.wkt
 
 def combine_geometries(wkts, precision=6):
     # https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.unary_union
-    geometries = [shapely.wkt.loads(x)[0] for x in wkts]
+    geometries = [shapely.wkt.loads(x).geoms[0] for x in wkts]
     union = unary_union(geometries)
     if not isinstance(union, MultiPolygon):
         union = MultiPolygon([union])


### PR DESCRIPTION
Amended code to use the modern approach to accessing parts of multipart geometry definitions using the Shapely library.