### PR TITLE
fix/shapely_deprecation_warning_II

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "validators",
         "xlrd==1.2.0",
         "openpyxl",
-        "Shapely==1.8.0",  # Version locking till https://github.com/shapely/shapely/issues/1364 is fixed
+        "Shapely==2.0.1",
         "SPARQLWrapper",
         "geojson",
         "spatialite",


### PR DESCRIPTION
Updated this library's requirements to use a tested, v2 version of Shapely.