### PR TITLE
Convert phase: Adds saving converted input as a csv

### DIFF
--- a/tests/unit/phase/test_convert.py
+++ b/tests/unit/phase/test_convert.py
@@ -15,53 +15,86 @@ def test_load_xlsm():
     assert log.mime_type == "application/vnd.ms-excel"
 
 
-def test_save_converted_geojson():
+def test_convert_features_to_csv_save_geojson():
     path = os.path.join(os.getcwd(), "tests/data/resource_examples/geojson.resource")
     log = DatasetResourceLog()
     ConvertPhase(
         path,
         dataset_resource_log=log,
-        custom_temp_dir="data",
+        output_path="converted/geojson.csv",
     ).process()
 
     assert os.path.isfile(os.path.join(os.getcwd(), "converted/geojson.csv"))
     os.remove(os.path.join(os.getcwd(), "converted/geojson.csv"))
 
 
-def test_save_converted_geopackage():
+def test_convert_features_to_csv_save_geopackage():
     path = os.path.join(os.getcwd(), "tests/data/resource_examples/geopackage.resource")
     log = DatasetResourceLog()
     ConvertPhase(
         path,
         dataset_resource_log=log,
-        custom_temp_dir="data",
+        output_path="converted/geopackage.csv",
     ).process()
 
     assert os.path.isfile(os.path.join(os.getcwd(), "converted/geopackage.csv"))
     os.remove(os.path.join(os.getcwd(), "converted/geopackage.csv"))
 
 
-def test_save_converted_gml():
+def test_convert_features_to_csv_save_converted_gml():
     path = os.path.join(os.getcwd(), "tests/data/resource_examples/gml.resource")
     log = DatasetResourceLog()
     ConvertPhase(
         path,
         dataset_resource_log=log,
-        custom_temp_dir="data",
+        output_path="wow/convert/gml.csv",
     ).process()
 
-    assert os.path.isfile(os.path.join(os.getcwd(), "converted/gml.csv"))
+    assert os.path.isfile(os.path.join(os.getcwd(), "wow/convert/gml.csv"))
     os.remove(os.path.join(os.getcwd(), "converted/gml.csv"))
 
 
-def test_save_converted_kml():
+def test_convert_features_to_csv_save_converted_kml():
     path = os.path.join(os.getcwd(), "tests/data/resource_examples/kml.resource")
     log = DatasetResourceLog()
     ConvertPhase(
         path,
         dataset_resource_log=log,
-        custom_temp_dir="data",
+        output_path="converted/kml.csv",
     ).process()
 
     assert os.path.isfile(os.path.join(os.getcwd(), "converted/kml.csv"))
     os.remove(os.path.join(os.getcwd(), "converted/kml.csv"))
+
+
+def test_convert_features_to_csv_save_converted_sqlite3():
+    path = os.path.join(
+        os.getcwd(),
+        "tests/expectations/resources_to_test_expectations/data_for_url_expect_test.sqlite3",
+    )
+    log = DatasetResourceLog()
+    ConvertPhase(
+        path,
+        dataset_resource_log=log,
+        output_path="converted/sqlite3.csv",
+    ).process()
+
+    assert os.path.isfile(
+        os.path.join(os.getcwd(), "converted/data_for_url_expect_test.csv")
+    )
+    os.remove(os.path.join(os.getcwd(), "converted/data_for_url_expect_test.csv"))
+
+
+def test_convert_features_to_csv_converted_not_saved():
+    path = os.path.join(
+        os.getcwd(),
+        "tests/expectations/resources_to_test_expectations/data_for_url_expect_test.sqlite3",
+    )
+    log = DatasetResourceLog()
+    ConvertPhase(
+        path,
+        dataset_resource_log=log,
+    ).process()
+
+    for root, dirs, files in os.walk(os.getcwd()):
+        assert "data_for_url_expect_test.csv" not in files

--- a/tests/unit/phase/test_convert.py
+++ b/tests/unit/phase/test_convert.py
@@ -86,6 +86,10 @@ def test_convert_features_to_csv_save_converted_sqlite3():
 
 
 def test_convert_features_to_csv_converted_not_saved():
+    files_before = []
+    for root, dirs, files in os.walk(os.getcwd()):
+        files_before.extend(files)
+
     path = os.path.join(
         os.getcwd(),
         "tests/expectations/resources_to_test_expectations/data_for_url_expect_test.sqlite3",
@@ -96,5 +100,8 @@ def test_convert_features_to_csv_converted_not_saved():
         dataset_resource_log=log,
     ).process()
 
+    files_after = []
     for root, dirs, files in os.walk(os.getcwd()):
-        assert "data_for_url_expect_test.csv" not in files
+        files_after.extend(files)
+
+    assert files_before == files_after

--- a/tests/unit/phase/test_convert.py
+++ b/tests/unit/phase/test_convert.py
@@ -76,7 +76,7 @@ def test_convert_features_to_csv_save_converted_sqlite3():
     ConvertPhase(
         path,
         dataset_resource_log=log,
-        output_path="converted/sqlite3.csv",
+        output_path="converted/data_for_url_expect_test.csv",
     ).process()
 
     assert os.path.isfile(

--- a/tests/unit/phase/test_convert.py
+++ b/tests/unit/phase/test_convert.py
@@ -47,10 +47,10 @@ def test_convert_features_to_csv_save_converted_gml():
     ConvertPhase(
         path,
         dataset_resource_log=log,
-        output_path="wow/convert/gml.csv",
+        output_path="converted/gml.csv",
     ).process()
 
-    assert os.path.isfile(os.path.join(os.getcwd(), "wow/convert/gml.csv"))
+    assert os.path.isfile(os.path.join(os.getcwd(), "converted/gml.csv"))
     os.remove(os.path.join(os.getcwd(), "converted/gml.csv"))
 
 

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -13,3 +13,17 @@ def test_load_xlsm():
     assert block["line-number"] == 1
     assert "OrganisationURI" in block["line"]
     assert log.mime_type == "application/vnd.ms-excel"
+
+
+def test_converted_csv_saved():
+    path = os.path.join(os.getcwd(), "tests/data/brentwood.xlsm")
+    log = DatasetResourceLog()
+    reader = ConvertPhase(
+        path,
+        dataset_resource_log=log,
+        custom_temp_dir="data",
+        custom_temp_file="input.csv",
+    ).process()
+    block = next(reader)
+    assert block["resource"] == "brentwood"
+    assert os.path.isfile(os.path.join(os.getcwd(), "data/input.csv"))

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -15,15 +15,53 @@ def test_load_xlsm():
     assert log.mime_type == "application/vnd.ms-excel"
 
 
-def test_converted_csv_saved():
-    path = os.path.join(os.getcwd(), "tests/data/brentwood.xlsm")
+def test_save_converted_geojson():
+    path = os.path.join(os.getcwd(), "tests/data/resource_examples/geojson.resource")
     log = DatasetResourceLog()
-    reader = ConvertPhase(
+    ConvertPhase(
         path,
         dataset_resource_log=log,
         custom_temp_dir="data",
-        custom_temp_file="input.csv",
     ).process()
-    block = next(reader)
-    assert block["resource"] == "brentwood"
-    assert os.path.isfile(os.path.join(os.getcwd(), "data/input.csv"))
+
+    assert os.path.isfile(os.path.join(os.getcwd(), "converted/geojson.csv"))
+    os.remove(os.path.join(os.getcwd(), "converted/geojson.csv"))
+
+
+def test_save_converted_geopackage():
+    path = os.path.join(os.getcwd(), "tests/data/resource_examples/geopackage.resource")
+    log = DatasetResourceLog()
+    ConvertPhase(
+        path,
+        dataset_resource_log=log,
+        custom_temp_dir="data",
+    ).process()
+
+    assert os.path.isfile(os.path.join(os.getcwd(), "converted/geopackage.csv"))
+    os.remove(os.path.join(os.getcwd(), "converted/geopackage.csv"))
+
+
+def test_save_converted_gml():
+    path = os.path.join(os.getcwd(), "tests/data/resource_examples/gml.resource")
+    log = DatasetResourceLog()
+    ConvertPhase(
+        path,
+        dataset_resource_log=log,
+        custom_temp_dir="data",
+    ).process()
+
+    assert os.path.isfile(os.path.join(os.getcwd(), "converted/gml.csv"))
+    os.remove(os.path.join(os.getcwd(), "converted/gml.csv"))
+
+
+def test_save_converted_kml():
+    path = os.path.join(os.getcwd(), "tests/data/resource_examples/kml.resource")
+    log = DatasetResourceLog()
+    ConvertPhase(
+        path,
+        dataset_resource_log=log,
+        custom_temp_dir="data",
+    ).process()
+
+    assert os.path.isfile(os.path.join(os.getcwd(), "converted/kml.csv"))
+    os.remove(os.path.join(os.getcwd(), "converted/kml.csv"))


### PR DESCRIPTION
This PR adds functionality to the convert phase so that when the input file (geojson, xlsm etc) is converted to a .csv file, this is saved to disk (rather than a temporary file). The location of where the file is saved is determined by arguments for the ConvertPhase class. If these arguments aren't present then the file isn't saved to disk.

This is required so the pipeline-runner can use the converted input .csv as part of its response.