### PR TITLE
Adding severity column functionality in log

### DIFF
--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -1,5 +1,6 @@
 import csv
 from datetime import datetime
+import pandas as pd
 
 
 def entry_date():
@@ -53,6 +54,28 @@ class IssueLog(Log):
                 "entry-number": entry_number or self.entry_number,
             }
         )
+
+    def add_severity_column(self, severity_mapping_path):
+        # Load only the 'severity' column from severity_mapping
+        severity_mapping = pd.read_csv(
+            severity_mapping_path, usecols=["issue-type", "severity"]
+        )
+
+        # Convert the existing log data to a DataFrame
+        log_df = pd.DataFrame(self.rows)
+
+        # Merge with severity_mapping based on 'issue-type'
+        merged_df = pd.merge(
+            log_df,
+            severity_mapping,
+            how="left",
+            left_on="issue-type",
+            right_on="issue-type",
+        )
+
+        # Add the new 'severity' column to the log data
+        self.fieldnames.append("severity")
+        self.rows = merged_df.to_dict(orient="records")
 
 
 class ColumnFieldLog(Log):

--- a/tests/data/specification/issue-type.csv
+++ b/tests/data/specification/issue-type.csv
@@ -1,0 +1,3 @@
+issue-type,severity,name,description,responsibility
+type1,sev1,test,desc1,internal
+type2,sev2,test,desc2,internal

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,0 +1,23 @@
+import pytest
+from digital_land.log import IssueLog
+
+test_collection_dir = "tests/data"
+
+
+@pytest.fixture
+def sample_issue_log_csv_path():
+    return test_collection_dir + "/specification/issue-type.csv"
+
+
+def test_add_severity_column(sample_issue_log_csv_path):
+    issue = IssueLog()
+    issue.log_issue("tesr", "type1", "value1")
+
+    # Confirm 'severity' field is not added to the fieldnames beforehand
+    assert "severity" not in issue.fieldnames
+
+    issue.add_severity_column(sample_issue_log_csv_path)
+
+    # Check if the 'severity' field is added to fieldnames
+    assert "severity" in issue.fieldnames
+    assert issue.rows[0]["severity"] == "sev1"


### PR DESCRIPTION
Ticket: https://trello.com/c/jY5HgQ2O/1108-add-severity-to-the-issue-log-in-pipeline-runner-validation-tool

The issue log currently in pipeline does not contain severity information like Warning, Information, Error, Notice etc.
Created a new method which will include this information only when called, this will be triggered specifically for pipeline runner API for now
