### PR TITLE
Appending Error Messages in pipeline runner API

### DIFF
--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -1,6 +1,7 @@
 import csv
 from datetime import datetime
 import pandas as pd
+import yaml
 
 
 def entry_date():
@@ -78,6 +79,21 @@ class IssueLog(Log):
             self.fieldnames.append("severity")
             self.fieldnames.append("description")
             self.rows = merged_df.to_dict(orient="records")
+
+    def appendErrorMessage(self, mapping_path):
+        # Read the mapping from the JSON config file
+        with open(mapping_path, "r") as f:
+            mapping_data = yaml.safe_load(f)
+        mapping = pd.DataFrame(mapping_data["mappings"])
+
+        # Update the 'description' column based on the mapping data
+        for row in self.rows:
+            mapping_row = mapping[
+                (mapping["field"] == row["field"])
+                & (mapping["issue-type"] == row["issue-type"])
+            ]
+            if not mapping_row["description"].empty:
+                row["description"] = mapping_row["description"].values[0]
 
 
 class ColumnFieldLog(Log):

--- a/tests/data/mapping.yaml
+++ b/tests/data/mapping.yaml
@@ -1,0 +1,4 @@
+mappings:
+- field: test
+  issue-type: type2
+  description: appended description

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -35,7 +35,6 @@ def mapping_data():
 
 
 def test_add_severity_column(issue_log_data):
-
     issue = IssueLog()
     issue.log_issue("test", "type1", "value1")
 
@@ -55,7 +54,6 @@ def test_add_severity_column(issue_log_data):
 
 
 def test_appendErrorMessage(issue_log_data, mapping_data):
-
     issue = IssueLog()
     issue.log_issue("test", "type1", "value1")
     issue.log_issue("test", "type2", "value2")

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,8 +1,7 @@
 import pytest
 from digital_land.log import IssueLog
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
 import pandas as pd
-import io
 
 
 @pytest.fixture
@@ -69,9 +68,7 @@ def test_appendErrorMessage(issue_log_data, mapping_data):
     assert issue.rows[1]["description"] == "desc2"
 
     # Patch the open function to return the fake YAML content
-    with patch(
-        "builtins.open", side_effect=lambda *args, **kwargs: io.StringIO(mapping_data)
-    ):
+    with patch("builtins.open", mock_open(read_data=mapping_data)):
         # Call the appendErrorMessage method with the fake mapping YAML
         issue.appendErrorMessage("fake_yaml_path.yaml")
 

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -9,6 +9,11 @@ def sample_issue_log_csv_path():
     return test_collection_dir + "/specification/issue-type.csv"
 
 
+@pytest.fixture
+def sample_mapping_path():
+    return test_collection_dir + "/mapping.yaml"
+
+
 def test_add_severity_column(sample_issue_log_csv_path):
     issue = IssueLog()
     issue.log_issue("test", "type1", "value1")
@@ -24,3 +29,19 @@ def test_add_severity_column(sample_issue_log_csv_path):
     assert "description" in issue.fieldnames
     assert issue.rows[0]["severity"] == "sev1"
     assert issue.rows[0]["description"] == "desc1"
+
+
+def test_appendErrorMessage(sample_issue_log_csv_path, sample_mapping_path):
+    issue = IssueLog()
+    issue.log_issue("test", "type1", "value1")
+    issue.log_issue("test", "type2", "value2")
+
+    issue.add_severity_column(sample_issue_log_csv_path)
+
+    assert issue.rows[0]["description"] == "desc1"
+    assert issue.rows[1]["description"] == "desc2"
+
+    issue.appendErrorMessage(sample_mapping_path)
+
+    assert issue.rows[0]["description"] == "desc1"
+    assert issue.rows[1]["description"] == "appended description"


### PR DESCRIPTION
Ticket: https://trello.com/c/dYjAIi79/1120-mvp-make-the-issues-meaningful-on-the-error-page

Appending error message description dynamically from issue log so it contains which field name is that error for specifically. This is specifically included for pipeline runner and will be called only when triggered from there.