### PR TITLE
Update add endpoints and lookups process to consider entity numbers in old-entity.csv

### DIFF
--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -515,11 +515,6 @@ def add_endpoints_and_lookups(
             writer = csv.writer(f)
             writer.writerow(list(lookups.schema.fieldnames))
 
-    if not os.path.exists(lookups.old_entity_path):
-        with open(lookups.old_entity_path, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(["old-entity", "status", "entity"])
-
     lookups.load_csv()
     for new_lookup in new_lookups:
         for idx, entry in enumerate(new_lookup):

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -517,6 +517,11 @@ def add_endpoints_and_lookups(
                 ["prefix", "resource", "organisation", "reference", "entity"]
             )
 
+    if not os.path.exists(lookups.old_entity_path):
+        with open(lookups.old_entity_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["old-entity", "status", "entity"])
+
     lookups.load_csv()
     for new_lookup in new_lookups:
         for idx, entry in enumerate(new_lookup):

--- a/digital_land/pipeline.py
+++ b/digital_land/pipeline.py
@@ -323,6 +323,7 @@ class Lookups:
     def __init__(self, directory=None) -> None:
         self.directory = directory or "pipeline"
         self.lookups_path = Path(directory) / "lookup.csv"
+        self.old_entity_path = Path(directory) / "old-entity.csv"
         self.entries = []
         self.schema = Schema("lookup")
         self.entity_num_gen = EntityNumGen()
@@ -376,7 +377,7 @@ class Lookups:
         except ValueError:
             return 0
 
-    def save_csv(self, lookups_path=None, entries=None):
+    def save_csv(self, lookups_path=None, entries=None, old_entity_path=None):
         path = lookups_path or self.lookups_path
 
         if entries is None:
@@ -389,12 +390,25 @@ class Lookups:
             f, fieldnames=self.schema.fieldnames, extrasaction="ignore"
         )
         writer.writeheader()
+
+        old_entity_path = self.old_entity_path
+        reader = csv.DictReader(open(old_entity_path, newline=""))
+
+        entity_values = []
+        for row in reader:
+            entity_values.append(row["old-entity"])
+            entity_values.append(row["entity"])
+
         for idx, entry in enumerate(entries):
             if not entry:
                 continue
             else:
                 if not entry.get("entity"):
-                    entry["entity"] = self.entity_num_gen.next()
+                    while True:
+                        generated_entity = self.entity_num_gen.next()
+                        if str(generated_entity) not in entity_values:
+                            entry["entity"] = generated_entity
+                            break
                 writer.writerow(entry)
 
     # @staticmethod

--- a/digital_land/pipeline.py
+++ b/digital_land/pipeline.py
@@ -391,13 +391,14 @@ class Lookups:
         )
         writer.writeheader()
 
-        old_entity_path = self.old_entity_path
-        reader = csv.DictReader(open(old_entity_path, newline=""))
-
         entity_values = []
-        for row in reader:
-            entity_values.append(row["old-entity"])
-            entity_values.append(row["entity"])
+        if os.path.exists(self.old_entity_path):
+            old_entity_path = self.old_entity_path
+            reader = csv.DictReader(open(old_entity_path, newline=""))
+
+            for row in reader:
+                entity_values.append(row["old-entity"])
+                entity_values.append(row["entity"])
 
         for idx, entry in enumerate(entries):
             if not entry:

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -255,9 +255,13 @@ def test_lookups_with_old_entity_numbers():
 
     with patch(
         "builtins.open", mock_open(read_data=mock_lookups_file_content), create=True
-    ), patch(
-        "builtins.open", mock_open(read_data=mock_old_entity_file_content), create=True
     ):
-        lookups.save_csv(mock_lookups_file, new_lookup, mock_old_entity_file)
+        with patch("os.path.exists", return_value=True):
+            with patch(
+                "builtins.open",
+                mock_open(read_data=mock_old_entity_file_content),
+                create=True,
+            ):
+                lookups.save_csv(mock_lookups_file, new_lookup, mock_old_entity_file)
 
     assert new_lookup[0]["entity"] == 5

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -237,7 +237,6 @@ def test_lookups_add_entry_failure(entry):
 
 
 def test_lookups_with_old_entity_numbers():
-
     lookups = Lookups("")
     new_lookup = [
         {
@@ -251,7 +250,6 @@ def test_lookups_with_old_entity_numbers():
 
     mock_lookups_file = Path("pipeline") / "lookup.csv"
     mock_lookups_file_content = "prefix,resource,organisation,reference,entity\nancient-woodland,,government-organisation:D1342,1,1\n"
-
     mock_old_entity_file = Path("pipeline") / "old-entity.csv"
     mock_old_entity_file_content = "old-entity,status,entity\n1,301,2\n3,301,4"
 


### PR DESCRIPTION
Card: https://trello.com/c/lFFK6cJl/977-update-process-for-add-endpoint-to-consider-old-entity-numbers

This PR updates the save_csv() function in the Lookups class
Before assigning new entity numbers to unassigned lookups it checked for those numbers in old-entity.csv file

If the entity number exists already in old-entity.csv (for any reason) then it is avoided and not assigned

This is to prevent any invalid redirections for any new entities added

**Test**
the test sets up a mock CSV file path and its content 
uses the patch to mock the open function
the test ensures that the new lookup doesn't get assigned a entity number that exists in the old-entity file