### PR TITLE
Assign entities command

### DIFF
--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import click
 
 from collections import defaultdict
+from digital_land.collection import Collection
 
 from digital_land.commands import (
     assign_entities,
@@ -288,10 +289,9 @@ def assign_entities_cmd(
     organisation_path,
 ):
     """
-    assigns entities for given resource/endpoint assuming it has already been added to collection
-    :param ctx:
+    Assigns entities for given resource in collection assuming it's endpoint has already been added to collection
     :param resource-path:
-    :param collection_dir:
+    :param collection_name:
     :return:
     """
     resource_file_path = Path(resource_path)
@@ -299,10 +299,12 @@ def assign_entities_cmd(
         logging.error("resource file not found")
         sys.exit(2)
 
+    collection = Collection(name=collection_name, directory=collection_dir)
+    collection.load()
+
     return assign_entities(
         [resource_file_path],
-        collection_name,
-        collection_dir,
+        collection,
         pipeline_dir,
         specification_dir,
         organisation_path,

--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -7,6 +7,7 @@ import click
 from collections import defaultdict
 
 from digital_land.commands import (
+    assign_entities,
     fetch,
     collect,
     collection_list_resources,
@@ -261,6 +262,45 @@ def add_endpoint_and_lookups_cmd(
 
     return add_endpoints_and_lookups(
         csv_file_path,
+        collection_name,
+        collection_dir,
+        pipeline_dir,
+        specification_dir,
+        organisation_path,
+    )
+
+
+@cli.command("assign-entities")
+@click.argument("resource-path", nargs=1, type=click.Path())
+@click.argument("collection-name", nargs=1, type=click.Path())
+@collection_dir
+@organisation_path
+@click.option(
+    "--specification-dir", "-s", type=click.Path(exists=True), default="specification/"
+)
+@click.option("--pipeline-dir", "-p", type=click.Path(exists=True), default="pipeline/")
+def assign_entities_cmd(
+    resource_path,
+    collection_name,
+    collection_dir,
+    specification_dir,
+    pipeline_dir,
+    organisation_path,
+):
+    """
+    assigns entities for given resource/endpoint assuming it has already been added to collection
+    :param ctx:
+    :param resource-path:
+    :param collection_dir:
+    :return:
+    """
+    resource_file_path = Path(resource_path)
+    if not resource_file_path.is_file():
+        logging.error("resource file not found")
+        sys.exit(2)
+
+    return assign_entities(
+        [resource_file_path],
         collection_name,
         collection_dir,
         pipeline_dir,

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -552,7 +552,6 @@ def assign_entities(
     organisation_path,
     tmp_dir="./var/cache",
 ):
-
     """
     :param csv_file_path:
     :param collection_name:

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -469,9 +469,6 @@ def add_endpoints_and_lookups(
     # reload log items
     collection.load_log_items()
 
-    # load specification
-    specification = Specification(specification_dir)
-
     print("")
     print("======================================================================")
     print("New Lookups")
@@ -479,59 +476,26 @@ def add_endpoints_and_lookups(
 
     # generate the lookup entries for each new resource
     dataset_resource_map = collection.dataset_resource_map()
-    new_lookups = []
 
     #  searching for the specific resources that we have downloaded
-    pipeline_name = None
     for dataset in dataset_resource_map:
+        resources_to_assign = []
         for resource in dataset_resource_map[dataset]:
             resource_endpoints = collection.resource_endpoints(resource)
-
             if any(
                 endpoint in [new_endpoint["endpoint"] for new_endpoint in endpoints]
                 for endpoint in resource_endpoints
             ):
                 resource_file_path = Path(collection_dir) / "resource" / resource
-                # annoyingly will need to re-establish pipeline each time as it's dataset specific
-                pipeline = Pipeline(pipeline_dir, dataset)
-                pipeline_name = pipeline.name
-                resource_lookups = get_resource_unidentified_lookups(
-                    input_path=resource_file_path,
-                    dataset=dataset,
-                    organisations=collection.resource_organisations(resource),
-                    pipeline=pipeline,
-                    specification=specification,
-                    tmp_dir=Path(tmp_dir).absolute(),
-                    org_csv_path=organisation_path,
-                )
-
-                new_lookups.append(resource_lookups)
-
-    # save new lookups to file
-    lookups = Lookups(pipeline_dir)
-    # Check if the lookups file exists, create it if not
-    if not os.path.exists(lookups.lookups_path):
-        with open(lookups.lookups_path, "w", newline="") as f:
-            writer = csv.writer(f)
-            writer.writerow(list(lookups.schema.fieldnames))
-
-    lookups.load_csv()
-    for new_lookup in new_lookups:
-        for idx, entry in enumerate(new_lookup):
-            lookups.add_entry(entry[0])
-
-    # save edited csvs
-    max_entity_num = lookups.get_max_entity(pipeline_name)
-    lookups.entity_num_gen.state["current"] = max_entity_num
-    lookups.entity_num_gen.state["range_max"] = specification.get_dataset_entity_max(
-        pipeline_name
-    )
-    lookups.entity_num_gen.state["range_min"] = specification.get_dataset_entity_min(
-        pipeline_name
-    )
-
-    collection.save_csv()
-    lookups.save_csv()
+                resources_to_assign.append(resource_file_path)
+        assign_entities(
+            resource_file_paths=resources_to_assign,
+            collection=collection,
+            pipeline_dir=pipeline_dir,
+            specification_dir=specification_dir,
+            organisation_path=organisation_path,
+            tmp_dir=tmp_dir,
+        )
 
 
 def resource_from_path(path):
@@ -545,17 +509,16 @@ def default_output_path(command, input_path):
 
 def assign_entities(
     resource_file_paths,
-    collection_name,
-    collection_dir,
+    collection,
     pipeline_dir,
     specification_dir,
     organisation_path,
     tmp_dir="./var/cache",
 ):
     """
-    :param csv_file_path:
-    :param collection_name:
-    :param collection_dir:
+    Assigns entities for the given resources in the given collection. The resources must have sources already added to the collection
+    :param resource_file_paths:
+    :param collection:
     :param pipeline_dir:
     :param specification_dir:
     :param organisation_path:
@@ -563,10 +526,6 @@ def assign_entities(
     :return:
     """
 
-    collection = Collection(name=collection_name, directory=collection_dir)
-    collection.load()
-
-    # load specification
     specification = Specification(specification_dir)
 
     print("")
@@ -574,33 +533,35 @@ def assign_entities(
     print("New Lookups")
     print("======================================================================")
 
-    # generate the lookup entries for each new resource
     dataset_resource_map = collection.dataset_resource_map()
-    # resource_dataset_map = {value: key for key, value in dataset_resource_map.items()}
     new_lookups = []
 
-    #  searching for the specific resources that we have downloaded
-    pipeline_name = None
+    dataset = None
     for resource_file_path in resource_file_paths:
         resource = os.path.splitext(os.path.basename(resource_file_path))[0]
-        dataset = next(
-            (k for k, v in dataset_resource_map.items() if v == {resource}), None
-        )
+        # Find dataset for resource
+        for dataset_key, resources in dataset_resource_map.items():
+            if resource in list(resources):
+                dataset = dataset_key
+                break
         # Chcek for None here in case resource hasn't been run through the pipeline
-        # annoyingly will need to re-establish pipeline each time as it's dataset specific
-        pipeline = Pipeline(pipeline_dir, dataset)
-        pipeline_name = pipeline.name
-        resource_lookups = get_resource_unidentified_lookups(
-            input_path=Path(resource_file_path),
-            dataset=dataset,
-            organisations=collection.resource_organisations(resource),
-            pipeline=pipeline,
-            specification=specification,
-            tmp_dir=Path(tmp_dir).absolute(),
-            org_csv_path=organisation_path,
-        )
-
-        new_lookups.append(resource_lookups)
+        if dataset is not None:
+            # annoyingly will need to re-establish pipeline each time as it's dataset specific
+            pipeline = Pipeline(pipeline_dir, dataset)
+            pipeline_name = pipeline.name
+            resource_lookups = get_resource_unidentified_lookups(
+                input_path=Path(resource_file_path),
+                dataset=dataset,
+                organisations=collection.resource_organisations(resource),
+                pipeline=pipeline,
+                specification=specification,
+                tmp_dir=Path(tmp_dir).absolute(),
+                org_csv_path=organisation_path,
+            )
+            new_lookups.append(resource_lookups)
+        else:
+            logging.error("Resource has not been processed by pipeline")
+            sys.exit(3)
 
     # save new lookups to file
     lookups = Lookups(pipeline_dir)

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -1,4 +1,5 @@
 import re
+import logging
 
 from .phase import Phase
 
@@ -112,5 +113,11 @@ class PrintLookupPhase(Phase):
                         "reference": reference,
                     }
                     self.new_lookup_entries.append([new_lookup])
-
+                elif not reference:
+                    logging.error(
+                        "No reference found for entry: "
+                        + str(entry_number)
+                        + " in resource: "
+                        + block["resource"]
+                    )
             yield block

--- a/tests/e2e/test_assign_entities.py
+++ b/tests/e2e/test_assign_entities.py
@@ -5,6 +5,7 @@ import urllib
 
 from pathlib import Path
 from click.testing import CliRunner
+from digital_land.collection import Collection
 
 from digital_land.commands import assign_entities
 from digital_land.pipeline import Lookups
@@ -207,10 +208,12 @@ def test_command_assign_entities(
     collection_name = "ancient-woodland"
     dataset_name = "ancient-woodland"
 
+    collection = Collection(name=collection_name, directory=collection_dir)
+    collection.load()
+
     assign_entities(
         resource_file_paths=["mock_csv.csv"],
-        collection_name=collection_name,
-        collection_dir=collection_dir,
+        collection=collection,
         specification_dir=specification_dir,
         organisation_path=organisation_path,
         pipeline_dir=pipeline_dir,
@@ -313,11 +316,12 @@ def test_command_assign_entities_no_reference_log(
     with no reference
     """
     collection_name = "ancient-woodland"
+    collection = Collection(name=collection_name, directory=collection_dir)
+    collection.load()
 
     assign_entities(
         resource_file_paths=["mock_csv.csv"],
-        collection_name=collection_name,
-        collection_dir=collection_dir,
+        collection=collection,
         specification_dir=specification_dir,
         organisation_path=organisation_path,
         pipeline_dir=pipeline_dir,

--- a/tests/e2e/test_assign_entities.py
+++ b/tests/e2e/test_assign_entities.py
@@ -1,0 +1,331 @@
+import pytest
+import os
+import csv
+import urllib
+
+from pathlib import Path
+from click.testing import CliRunner
+
+from digital_land.commands import assign_entities
+from digital_land.pipeline import Lookups
+from digital_land.cli import assign_entities_cmd
+from digital_land.specification import Specification
+
+
+@pytest.fixture
+def mock_resource():
+    row1 = {
+        "reference": "Ref1",
+        "organisation": "government-organisation:D1342",
+        "value": "test",
+    }
+    row2 = {
+        "reference": "Ref2",
+        "organisation": "government-organisation:D1342",
+        "value": "test",
+    }
+    row3 = {
+        "reference": "",
+        "organisation": "government-organisation:D1342",
+        "value": "test",
+    }
+
+    mock_csv_path = Path("mock_csv.csv")
+    with open(mock_csv_path, "w", encoding="utf-8") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=row1.keys())
+        dictwriter.writeheader()
+        dictwriter.writerow(row1)
+        dictwriter.writerow(row2)
+        dictwriter.writerow(row3)
+
+    yield mock_csv_path
+
+    os.remove(mock_csv_path)
+
+
+@pytest.fixture
+def collection_dir(tmp_path):
+    collection_dir = os.path.join(tmp_path, "collection")
+    os.makedirs(collection_dir, exist_ok=True)
+
+    # create source
+    source_fieldnames = [
+        "attribution",
+        "collection",
+        "documentation-url",
+        "endpoint",
+        "licence",
+        "organisation",
+        "pipelines",
+        "entry-date",
+        "start-date",
+        "end-date",
+    ]
+
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=source_fieldnames)
+        dictwriter.writeheader()
+
+    endpoint_fieldnames = [
+        "endpoint",
+        "endpoint-url",
+        "parameters",
+        "plugin",
+        "entry-date",
+        "start-date",
+        "end-date",
+    ]
+    with open(os.path.join(collection_dir, "endpoint.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=endpoint_fieldnames)
+        dictwriter.writeheader()
+
+    resource_fieldnames = [
+        "resource",
+        "bytes",
+        "organisations",
+        "datasets",
+        "endpoints",
+        "start-date",
+        "end-date",
+    ]
+    row = {
+        "resource": "mock_csv",
+        "datasets": "anciend-woodland",
+        "endpoints": "endpoint",
+    }
+    with open(os.path.join(collection_dir, "resource.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=resource_fieldnames)
+        dictwriter.writeheader()
+        dictwriter.writerow(row)
+
+    log_fieldnames = [
+        "bytes",
+        "content-type",
+        "elapsed",
+        "endpoint",
+        "resource",
+        "status",
+        "entry-date",
+        "start-date",
+        "end-date",
+        "exception",
+    ]
+    with open(os.path.join(collection_dir, "log.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=log_fieldnames)
+        dictwriter.writeheader()
+
+    source_fieldnames = [
+        "source",
+        "attribution",
+        "collection",
+        "documentation-url",
+        "endpoint",
+        "licence",
+        "organisation",
+        "pipelines",
+        "entry-date",
+        "start-date",
+        "end-date",
+    ]
+    row = {"endpoint": "endpoint", "pipelines": "ancient-woodland"}
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=source_fieldnames)
+        dictwriter.writeheader()
+        dictwriter.writerow(row)
+
+    return collection_dir
+
+
+@pytest.fixture(scope="session")
+def specification_dir(tmp_path_factory):
+    specification_dir = tmp_path_factory.mktemp("specification")
+    source_url = "https://raw.githubusercontent.com/digital-land/"
+    specification_csvs = [
+        "attribution.csv",
+        "licence.csv",
+        "typology.csv",
+        "theme.csv",
+        "collection.csv",
+        "dataset.csv",
+        "dataset-field.csv",
+        "field.csv",
+        "datatype.csv",
+        "prefix.csv",
+        # deprecated ..
+        "pipeline.csv",
+        "dataset-schema.csv",
+        "schema.csv",
+        "schema-field.csv",
+    ]
+    for specification_csv in specification_csvs:
+        urllib.request.urlretrieve(
+            f"{source_url}/specification/main/specification/{specification_csv}",
+            os.path.join(specification_dir, specification_csv),
+        )
+
+    return specification_dir
+
+
+@pytest.fixture
+def organisation_csv(tmp_path):
+    organisation_path = os.path.join(tmp_path, "organisation.csv")
+    urllib.request.urlretrieve(
+        "https://raw.githubusercontent.com/digital-land/organisation-dataset/main/collection/organisation.csv",
+        organisation_path,
+    )
+    return organisation_path
+
+
+@pytest.fixture
+def pipeline_dir(tmp_path):
+    pipeline_dir = os.path.join(tmp_path, "pipeline")
+    os.makedirs(pipeline_dir, exist_ok=True)
+
+    fieldnames = {
+        "prefix",
+        "resource",
+        "entry-number",
+        "organisation",
+        "reference",
+        "entity",
+    }
+
+    with open(os.path.join(pipeline_dir, "lookup.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=fieldnames)
+        dictwriter.writeheader()
+
+    return pipeline_dir
+
+
+def test_command_assign_entities(
+    collection_dir, pipeline_dir, specification_dir, organisation_path, mock_resource
+):
+
+    """
+    This tests a function that, given a specific resource hash for an endpoint already added to the system,
+    should identify any missing lookups and add them to lookup.csv
+    """
+    collection_name = "ancient-woodland"
+    dataset_name = "ancient-woodland"
+
+    assign_entities(
+        resource_file_paths=["mock_csv.csv"],
+        collection_name=collection_name,
+        collection_dir=collection_dir,
+        specification_dir=specification_dir,
+        organisation_path=organisation_path,
+        pipeline_dir=pipeline_dir,
+    )
+
+    lookups = Lookups(pipeline_dir)
+    lookups.load_csv()
+
+    specification = Specification(specification_dir)
+    entity_range_min = specification.get_dataset_entity_min(dataset_name)
+    entity_range_max = specification.get_dataset_entity_max(dataset_name)
+
+    assert len(lookups.entries) > 0
+    assert lookups.entries[0]["entity"] == entity_range_min
+    assert lookups.entries[0]["reference"] == "Ref1"
+    assert lookups.entries[0]["prefix"] == dataset_name
+    assert lookups.entries[1]["entity"] == str(int(entity_range_min) + 1)
+    assert lookups.entries[1]["reference"] == "Ref2"
+    assert lookups.entries[1]["prefix"] == dataset_name
+
+    entity_numbers = []
+    for entry in lookups.entries:
+        entity_numbers.append(entry.get("entity"))
+    assert min(int(entity) for entity in entity_numbers) >= int(entity_range_min)
+    assert max(int(entity) for entity in entity_numbers) <= int(entity_range_max)
+
+
+def test_cli_assign_entities_success(
+    collection_dir, pipeline_dir, specification_dir, organisation_path, mock_resource
+):
+
+    """
+    Tests assign entities from cli
+    """
+
+    collection_name = "ancient-woodland"
+    resource_path = "mock_csv.csv"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        assign_entities_cmd,
+        [
+            resource_path,
+            collection_name,
+            # these will be optional to the user but included here to point at files stored elsewhere
+            "--collection-dir",
+            collection_dir,
+            "--pipeline-dir",
+            pipeline_dir,
+            "--specification-dir",
+            specification_dir,
+            "--organisation-path",
+            organisation_path,
+        ],
+    )
+
+    assert result.exit_code == 0, f"{result.stdout}"
+
+
+def test_cli_assign_entities_failure_resource_not_found(
+    collection_dir, pipeline_dir, specification_dir, organisation_path, mock_resource
+):
+
+    """
+    Tests assign entities from cli when resource path is incorrect
+    """
+
+    collection_name = "ancient-woodland"
+    resource_path = ""
+
+    runner = CliRunner()
+    result = runner.invoke(
+        assign_entities_cmd,
+        [
+            resource_path,
+            collection_name,
+            # these will be optional to the user but included here to point at files stored elsewhere
+            "--collection-dir",
+            collection_dir,
+            "--pipeline-dir",
+            pipeline_dir,
+            "--specification-dir",
+            specification_dir,
+            "--organisation-path",
+            organisation_path,
+        ],
+    )
+
+    assert result.exit_code == 2, f"{result.stdout}"
+
+
+def test_command_assign_entities_no_reference_log(
+    caplog,
+    collection_dir,
+    pipeline_dir,
+    specification_dir,
+    organisation_path,
+    mock_resource,
+):
+
+    """
+    This tests that the assign entities command logs a warning when there is an entry
+    with no reference
+    """
+    collection_name = "ancient-woodland"
+
+    assign_entities(
+        resource_file_paths=["mock_csv.csv"],
+        collection_name=collection_name,
+        collection_dir=collection_dir,
+        specification_dir=specification_dir,
+        organisation_path=organisation_path,
+        pipeline_dir=pipeline_dir,
+    )
+
+    assert "No reference" in caplog.text
+    assert "mock_csv" in caplog.text

--- a/tests/e2e/test_assign_entities.py
+++ b/tests/e2e/test_assign_entities.py
@@ -200,7 +200,6 @@ def pipeline_dir(tmp_path):
 def test_command_assign_entities(
     collection_dir, pipeline_dir, specification_dir, organisation_path, mock_resource
 ):
-
     """
     This tests a function that, given a specific resource hash for an endpoint already added to the system,
     should identify any missing lookups and add them to lookup.csv
@@ -242,7 +241,6 @@ def test_command_assign_entities(
 def test_cli_assign_entities_success(
     collection_dir, pipeline_dir, specification_dir, organisation_path, mock_resource
 ):
-
     """
     Tests assign entities from cli
     """
@@ -274,7 +272,6 @@ def test_cli_assign_entities_success(
 def test_cli_assign_entities_failure_resource_not_found(
     collection_dir, pipeline_dir, specification_dir, organisation_path, mock_resource
 ):
-
     """
     Tests assign entities from cli when resource path is incorrect
     """
@@ -311,7 +308,6 @@ def test_command_assign_entities_no_reference_log(
     organisation_path,
     mock_resource,
 ):
-
     """
     This tests that the assign entities command logs a warning when there is an entry
     with no reference


### PR DESCRIPTION
Adds a new command to digital land python, 'assign entities'. Refactors the existing add-endpoints-and-lookups to use the new assign entities functions so there is only a single way of assigning entities.