### PR TITLE
check for duplicate endpoints

### DIFF
--- a/digital_land/collection.py
+++ b/digital_land/collection.py
@@ -218,13 +218,13 @@ class EndpointStore(CSVStore):
                 for item in self.entries
                 if item["endpoint"] == endpoint_item["endpoint"]
                 and item["endpoint-url"] == endpoint_item["endpoint-url"]
-                and item["plugin"] == endpoint_item["plugin"]
-                and item["start-date"] == endpoint_item["start-date"]
             ]
         )
 
         if existing_entries > 0:
-            # print(f">>> INFO: endpoint already exists - {endpoint_item['endpoint']}")
+            print(">>> INFO: endpoint already exists")
+            print(f">>> Endpoint hash {endpoint_item['endpoint']}")
+            print(f">>> Endpoint URL {endpoint_item['endpoint-url']}")
             return False
 
         return True


### PR DESCRIPTION
Card: https://trello.com/c/cq7Zoajy/1012-do-not-add-duplicate-endpoints
 
This PR updates the add-endpoints-and-lookups script to check for duplicate endpoints considering the endpoint hash and endpoint URL
If the new endpoint has an endpoint hash and URL that already exists then the script will display a message like this
 
```
>>> INFO: endpoint already exists
>>> Endpoint hash cdb4d88dca0bef8defe13d71624a46e7e851750a750a5467d53cb1bf273ab973
>>> Endpoint URL https://www.example.com/ 
```
 
The Test first adds an endpoint and checks if the script performs as expected when a duplicated endpoint is added next