### PR TITLE
Add entity redirects

### DIFF
--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from digital_land.collection import Collection
 
 from digital_land.commands import (
+    add_redirections,
     assign_entities,
     fetch,
     collect,
@@ -310,3 +311,22 @@ def assign_entities_cmd(
         specification_dir,
         organisation_path,
     )
+
+
+@cli.command("add-redirections")
+@click.argument("csv_path", nargs=1, type=click.Path())
+@click.option("--pipeline-dir", "-p", type=click.Path(exists=True), default="pipeline/")
+def add_redirections_cmd(csv_path, pipeline_dir):
+    """
+    Add redirections to the old-entity file based on records in csv_path
+    :param resource_path:
+    :param collection_name:
+    :return:
+    """
+
+    csv_file_path = Path(csv_path)
+    if not csv_file_path.is_file():
+        logging.error("no csv file was provided")
+        sys.exit(2)
+
+    return add_redirections(csv_file_path, pipeline_dir)

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -746,3 +746,48 @@ def process_data_in_batches(entities, flattened_dir, dataset_name):
         )
 
     return feature_collection
+
+
+def add_redirections(csv_file_path, pipeline_dir):
+    """
+    :param csv_file_path:
+    :param pipeline_dir:
+    :return:
+    """
+    expected_cols = [
+        "entity_HE",
+        "entity_LPA",
+    ]
+
+    old_entity_path = Path(pipeline_dir) / "old-entity.csv"
+
+    with open(csv_file_path) as new_endpoints_file:
+        reader = csv.DictReader(new_endpoints_file)
+        csv_columns = reader.fieldnames
+
+        for expected_col in expected_cols:
+            if expected_col not in csv_columns:
+                raise Exception(f"required column ({expected_col}) not found in csv")
+
+        fieldnames = ["old-entity", "status", "entity"]
+
+        f = open(old_entity_path, "a", newline="")
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        if f.tell() == 0:
+            writer.writeheader()
+
+        for row in reader:
+            if row["entity_HE"] == "" or row["entity_LPA"] == "":
+                print(
+                    "Missing entity number for",
+                    row["entity_LPA"] if row["entity_HE"] == "" else row["entity_HE"],
+                )
+            else:
+                writer.writerow(
+                    {
+                        "old-entity": row["entity_HE"],
+                        "status": "301",
+                        "entity": row["entity_LPA"],
+                    }
+                )
+    print("Redirections added to old-entity.csv")

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -755,8 +755,8 @@ def add_redirections(csv_file_path, pipeline_dir):
     :return:
     """
     expected_cols = [
-        "entity_HE",
-        "entity_LPA",
+        "entity_source",
+        "entity_destination",
     ]
 
     old_entity_path = Path(pipeline_dir) / "old-entity.csv"
@@ -777,17 +777,21 @@ def add_redirections(csv_file_path, pipeline_dir):
             writer.writeheader()
 
         for row in reader:
-            if row["entity_HE"] == "" or row["entity_LPA"] == "":
+            if row["entity_source"] == "" or row["entity_destination"] == "":
                 print(
                     "Missing entity number for",
-                    row["entity_LPA"] if row["entity_HE"] == "" else row["entity_HE"],
+                    (
+                        row["entity_destination"]
+                        if row["entity_source"] == ""
+                        else row["entity_source"]
+                    ),
                 )
             else:
                 writer.writerow(
                     {
-                        "old-entity": row["entity_HE"],
+                        "old-entity": row["entity_source"],
                         "status": "301",
-                        "entity": row["entity_LPA"],
+                        "entity": row["entity_destination"],
                     }
                 )
     print("Redirections added to old-entity.csv")

--- a/tests/e2e/test_add_redicrections.py
+++ b/tests/e2e/test_add_redicrections.py
@@ -13,8 +13,8 @@ def csv_file_path(tmp_path):
     entities_csv_path = os.path.join(tmp_path, "redirections.csv")
 
     row = {
-        "entity_LPA": "100",
-        "entity_HE": "200",
+        "entity_destination": "100",
+        "entity_source": "200",
     }
     fieldnames = row.keys()
     with open(entities_csv_path, "w") as f:

--- a/tests/e2e/test_add_redicrections.py
+++ b/tests/e2e/test_add_redicrections.py
@@ -1,0 +1,41 @@
+import os
+import csv
+import pytest
+from pathlib import Path
+from digital_land.commands import add_redirections
+
+
+@pytest.fixture
+def csv_file_path(tmp_path):
+    """
+    Populates the input csv file with required data and returns the file path
+    """
+    entities_csv_path = os.path.join(tmp_path, "redirections.csv")
+
+    row = {
+        "entity_LPA": "100",
+        "entity_HE": "200",
+    }
+    fieldnames = row.keys()
+    with open(entities_csv_path, "w") as f:
+
+        dictwriter = csv.DictWriter(f, fieldnames=fieldnames)
+        dictwriter.writeheader()
+        dictwriter.writerow(row)
+
+    return entities_csv_path
+
+
+def test_add_redirections_success(csv_file_path, tmp_path):
+
+    add_redirections(csv_file_path=csv_file_path, pipeline_dir=tmp_path)
+    old_entity_path = Path(tmp_path) / "old-entity.csv"
+
+    with open(old_entity_path, "r") as mock_file:
+        reader = csv.DictReader(mock_file)
+        rows = list(reader)
+
+        assert len(rows) == 1
+        assert rows[0]["old-entity"] == "200"
+        assert rows[0]["status"] == "301"
+        assert rows[0]["entity"] == "100"


### PR DESCRIPTION
Ref: https://trello.com/c/kHTiSrmx/999-merge-existing-geographically-duplicated-conservation-area-entities

This PR creates a command "add-redirections" which takes a csv file (which contains list of duplicates entities) and assign redirects for those to the old-entity.csv (to merge the entities)

