### PR TITLE
Replace None with an empty string during map phase.

### DIFF
--- a/digital_land/phase/map.py
+++ b/digital_land/phase/map.py
@@ -75,7 +75,7 @@ class MapPhase(Phase):
                 if headers[header] == "IGNORE":
                     continue
 
-                o[headers[header]] = row.get(header)
+                o[headers[header]] = row.get(header) or ""
 
             block["row"] = o
 

--- a/tests/unit/phase/test_map.py
+++ b/tests/unit/phase/test_map.py
@@ -131,3 +131,13 @@ def test_map_column_names_with_underscores_when_column_in_specification():
         output
         == "Organisation-Label,SiteNameAddress,end-date\r\ncol-1-val,,col-2-val\r\n"
     )
+
+
+def test_null_to_empty_string():
+    fieldnames = ["Nada"]
+    columns = {}
+
+    output = list(MapPhase(fieldnames, columns).process([{"row":{"Nada":None}}]))
+
+    assert len(output) == 1
+    assert output[0]['row']['Nada'] == ""

--- a/tests/unit/phase/test_map.py
+++ b/tests/unit/phase/test_map.py
@@ -137,7 +137,7 @@ def test_null_to_empty_string():
     fieldnames = ["Nada"]
     columns = {}
 
-    output = list(MapPhase(fieldnames, columns).process([{"row":{"Nada":None}}]))
+    output = list(MapPhase(fieldnames, columns).process([{"row": {"Nada": None}}]))
 
     assert len(output) == 1
-    assert output[0]['row']['Nada'] == ""
+    assert output[0]["row"]["Nada"] == ""


### PR DESCRIPTION
This reinstates the previous behavior of the map phase when a column was not present.