### PR TITLE
Adds .get to when attempting to grab "pipeline" field

### DIFF
--- a/digital_land/pipeline.py
+++ b/digital_land/pipeline.py
@@ -68,7 +68,7 @@ class Pipeline:
 
     def reader(self, filename):
         for row in self.file_reader(filename):
-            row["dataset"] = row.get("dataset", "") or row["pipeline"]
+            row["dataset"] = row.get("dataset", "") or row.get("pipeline", "")
             if row["dataset"] and row["dataset"] != self.name:
                 continue
             yield row


### PR DESCRIPTION
The config headers are being made consistent across all collections according to the specification. Notably here "dataset" is in the specification but "pipeline" isn't, so usages of "pipeline" as a header have been renamed to "dataset". As part of this, the new headers were tested on the TPO collection when a bug was noticed as the pipeline does not safely access the "pipeline" field in one circumstance.

The call for the "pipeline" field has been left in for legacy reasons even though with the new headers it shouldn't be needed