### PR TITLE
Handle "efficient json" format

### DIFF
--- a/digital_land/phase/convert.py
+++ b/digital_land/phase/convert.py
@@ -115,24 +115,35 @@ def convert_features_to_csv(input_path, output_path=None):
     return output_path
 
 
+def save_efficient_json_as_csv(output_path, columns, data):
+    with open(output_path, "w") as csv_file:
+        cw = csv.writer(csv_file)
+        cw.writerow(columns)
+
+        for row in data:
+            cw.writerow(row)
+
+
 def convert_json_to_csv(input_path, output_path=None):
     with open(input_path, "r") as json:
         js = json_stream.load(json)
+
         columns = None
+        data = None
 
         for item in js.items():
             if item[0] in ["columns"]:
                 columns = [x for x in item[1].persistent()]
+                if data is not None:
+                    save_efficient_json_as_csv(output_path, columns, data)
+                    return output_path
 
-            if item[0] in ["data"] and columns is not None:
-                with open(output_path, "w") as csv_file:
-                    cw = csv.writer(csv_file)
-                    cw.writerow(columns)
-
-                    for row in item[1]:
-                        cw.writerow(row)
-
-                return output_path
+            if item[0] in ["data"]:
+                if columns is not None:
+                    save_efficient_json_as_csv(output_path, columns, item[1])
+                    return output_path
+                else:
+                    data = [x for x in item[1].persistent()]
 
         return convert_features_to_csv(input_path, output_path)
 

--- a/digital_land/phase/convert.py
+++ b/digital_land/phase/convert.py
@@ -116,10 +116,8 @@ def convert_features_to_csv(input_path, output_path=None):
 
 
 def convert_json_to_csv(input_path, output_path=None):
-
     with open(input_path, "r") as json:
         js = json_stream.load(json)
-
         columns = None
 
         for item in js.items():
@@ -131,9 +129,12 @@ def convert_json_to_csv(input_path, output_path=None):
                     cw = csv.writer(csv_file)
                     cw.writerow(columns)
 
+                    for row in item[1]:
+                        cw.writerow(row)
+
                 return output_path
 
-            return convert_features_to_csv(input_path, output_path)
+        return convert_features_to_csv(input_path, output_path)
 
 
 class ConvertPhase(Phase):

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "pyyaml",
         "dataclasses-json",
         "pydantic",
+        "json-stream",
     ],
     entry_points={"console_scripts": ["digital-land=digital_land.cli:cli"]},
     setup_requires=["pytest-runner"],

--- a/tests/data/resource_examples/json_efficient_format.resource
+++ b/tests/data/resource_examples/json_efficient_format.resource
@@ -1,0 +1,7 @@
+{
+    "name": "planxtpocsv",
+    "columns": ["reference","name","document_url","documentation_url","notes","made_date","start_date","confirmation_date","end_date","entry_date"],
+    "data": [    
+        ["ref", "name", null, null, null, "1964-05-21", "1964-05-21", "1964-10-14", null, "1964-05-21"]
+    ]
+}

--- a/tests/data/resource_examples/json_efficient_format_data_first.resource
+++ b/tests/data/resource_examples/json_efficient_format_data_first.resource
@@ -1,0 +1,7 @@
+{
+    "name": "planxtpocsv",
+    "data": [    
+        ["ref", "name", null, null, null, "1964-05-21", "1964-05-21", "1964-10-14", null, "1964-05-21"]
+    ],
+    "columns": ["reference","name","document_url","documentation_url","notes","made_date","start_date","confirmation_date","end_date","entry_date"]
+}

--- a/tests/unit/phase/test_convert.py
+++ b/tests/unit/phase/test_convert.py
@@ -78,3 +78,26 @@ class TestConvertPhase:
         block = next(reader)
         assert block["line"][0] == "ref"
         assert block["line"][1] == "name"
+
+    def test_process_efficient_json_format_data_first(self, tmp_path):
+        path = os.path.join(
+            os.getcwd(),
+            "tests/data/resource_examples/json_efficient_format_data_first.resource",
+        )
+        output_path = os.path.join(
+            tmp_path, "converted/json_efficient_format_data_first.resource.csv"
+        )
+        log = DatasetResourceLog()
+        reader = ConvertPhase(
+            path, dataset_resource_log=log, output_path=output_path
+        ).process()
+
+        assert os.path.isfile(output_path)
+
+        headers = next(reader)
+        assert headers["line"][0] == "reference"
+        assert headers["line"][1] == "name"
+
+        block = next(reader)
+        assert block["line"][0] == "ref"
+        assert block["line"][1] == "name"

--- a/tests/unit/phase/test_convert.py
+++ b/tests/unit/phase/test_convert.py
@@ -56,3 +56,25 @@ class TestConvertPhase:
             files_after.extend(files)
 
         assert files_before == files_after
+
+    def test_process_efficient_json_format(self, tmp_path):
+        path = os.path.join(
+            os.getcwd(), "tests/data/resource_examples/json_efficient_format.resource"
+        )
+        output_path = os.path.join(
+            tmp_path, "converted/json_efficient_format.resource.csv"
+        )
+        log = DatasetResourceLog()
+        reader = ConvertPhase(
+            path, dataset_resource_log=log, output_path=output_path
+        ).process()
+
+        assert os.path.isfile(output_path)
+
+        headers = next(reader)
+        assert headers["line"][0] == "reference"
+        assert headers["line"][1] == "name"
+
+        block = next(reader)
+        assert block["line"][0] == "ref"
+        assert block["line"][1] == "name"


### PR DESCRIPTION
For json files, we check if the file is in 'efficient json' format we convert it ourselves. Otherwise we call out to ogr2ogr as before.
