### PR TITLE
Adds output path generation if none is supplied to convert phase (efficient json format)

### DIFF
--- a/digital_land/phase/convert.py
+++ b/digital_land/phase/convert.py
@@ -116,6 +116,8 @@ def convert_features_to_csv(input_path, output_path=None):
 
 
 def save_efficient_json_as_csv(output_path, columns, data):
+    if not output_path:
+        output_path = tempfile.NamedTemporaryFile(suffix=".csv").name
     with open(output_path, "w") as csv_file:
         cw = csv.writer(csv_file)
         cw.writerow(columns)


### PR DESCRIPTION
In the convert phase when handling the 'efficient' json format, if no output path was given to the phase then no conversion would happen. This PR sets the output path to a temporary file if none is supplied