### PR TITLE
Handling datetime precision >=7 cases

### DIFF
--- a/digital_land/datatype/date.py
+++ b/digital_land/datatype/date.py
@@ -50,6 +50,14 @@ class DateDataType(DataType):
                     if pattern == "%s":
                         date = datetime.utcfromtimestamp(float(value) / 1000.0)
                         return date.strftime("%Y-%m-%d")
+                    if "%f" in pattern:
+                        datearr = value.split(".")
+                        if len(datearr) > 1 and len(datearr[1].split("+")[0]) > 6:
+                            s = len(datearr[1].split("+")[0]) - 6
+                            value = value.split("+")[0][:-s]
+                        date = datetime.strptime(value, pattern)
+                        return date.strftime("%Y-%m-%d")
+
                 except ValueError:
                     pass
 

--- a/tests/unit/test_date.py
+++ b/tests/unit/test_date.py
@@ -31,8 +31,12 @@ def test_date_normalise():
     assert date.normalise("Jan-20") == "2020-01-01"
     assert date.normalise("144892800000") == "1974-08-05"
     assert date.normalise("-521164800000") == "1953-06-27"
+    assert date.normalise("2024-07-02T13:49:47.676511") == "2024-07-02"
     assert date.normalise("2024-07-03T13:49:47.676511+01:00") == "2024-07-03"
-    assert date.normalise("2024-07-03T13:49:47.676511") == "2024-07-03"
+    assert date.normalise("2024-07-04T13:41:46.7084023+01:00") == "2024-07-04"
+    assert date.normalise("2024-07-04T13:41:46.708402345678") == "2024-07-04"
+    assert date.normalise("2024-07-04T13:41:46.708402345678+01:00") == "2024-07-04"
+    assert date.normalise("2024-07-04T13:41:46.708402345678Z") == "2024-07-04"
 
     # risky attempts ..
     assert date.normalise("2020-13-12") == "2020-12-13"


### PR DESCRIPTION
There are few entities for which start-date is coming with 7dp accuracy, which python does not support. Adding a hacky way to handle these cases (strip the final dp in cases like these) 