### PR TITLE
Priotise endpoint/resource column mappings

### DIFF
--- a/digital_land/pipeline.py
+++ b/digital_land/pipeline.py
@@ -234,6 +234,11 @@ class Pipeline:
         for key in general_columns:
             if key in result:
                 continue
+            if (
+                general_columns[key] in endpoint_columns.values()
+                or general_columns[key] in resource_columns.values()
+            ):
+                continue
             result[key] = general_columns[key]
         return result
 

--- a/tests/data/pipeline/column.csv
+++ b/tests/data/pipeline/column.csv
@@ -6,5 +6,6 @@ pipeline-one,,una,one
 pipeline-one,,uno,one
 pipeline-one,,dos,two
 pipeline-one,,thirdcolumn,three
+pipeline-one,,quatre,four
 pipeline-one,some-resource,quatro,four
 pipeline-three,,adress,address

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -209,7 +209,18 @@ def test_columns():
         "un": "one",
         "una": "one",
         "uno": "one",
+        "quatre": "four",
     }
+
+
+def test_resource_column_mapping_takes_priority():
+    p = Pipeline("tests/data/pipeline/", "pipeline-one")
+    column = p.columns("some-resource")
+
+    assert "quatre" not in column
+    assert "quatro" in column
+    assert "un" in column
+    assert "due" in column
 
 
 def test_resource_specific_columns():


### PR DESCRIPTION
Given multiple columns that map to same field endpoint or resource specific column mappings should take priority.

e.g for these columns mappings where two different columns are mapped to the same field.

```
pipeline,resource,column,field
pipeline-one,,quatre,four
pipeline-one,some-resource,quatro,four
```
The resulting mappings seems to contain both of them.
This PR updates this such that the resulting mapping has only one resource specific column mapping in it.

The other general mappings remain the same.
