### PR TITLE
Update load lookups

### DIFF
--- a/digital_land/pipeline.py
+++ b/digital_land/pipeline.py
@@ -177,13 +177,14 @@ class Pipeline:
 
             # composite key, ordered by specificity
             resource_lookup = self.lookup.setdefault(row.get("resource", ""), {})
-            resource_lookup[
-                lookup_key(
-                    entry_number=entry_number,
-                    prefix=prefix,
-                    reference=reference,
-                )
-            ] = row["entity"]
+            if entry_number:
+                resource_lookup[
+                    lookup_key(
+                        entry_number=entry_number,
+                        prefix=prefix,
+                        reference=reference,
+                    )
+                ] = row["entity"]
 
             organisation = row.get("organisation", "")
             # replace local-authority-eng while we migrate

--- a/tests/e2e/test_add_endpoints_and_lookups.py
+++ b/tests/e2e/test_add_endpoints_and_lookups.py
@@ -82,6 +82,18 @@ def mock_resource(tmp_path):
 
 
 @pytest.fixture
+def mock_resource_identifical_reference(tmp_path):
+    data = {"reference": "ABC_0001", "value": "test"}
+    mock_csv_path = Path(tmp_path, "mock_csv.csv")
+    with open(mock_csv_path, "w", encoding="utf-8") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=data.keys())
+        dictwriter.writeheader()
+        dictwriter.writerow(data)
+
+    return mock_csv_path
+
+
+@pytest.fixture
 def collection_dir(tmp_path):
     collection_dir = os.path.join(tmp_path, "collection")
     os.makedirs(collection_dir, exist_ok=True)
@@ -172,7 +184,7 @@ def pipeline_dir(tmp_path, specification_dir):
     row = {
         "prefix": collection_name,
         "resource": "",
-        "entry-number": 1,
+        "entry-number": "",
         "organisation": "local-authority-eng:ABC",
         "reference": "ABC_0001",
         "entity": entity_range_min,
@@ -257,6 +269,51 @@ def test_command_add_endpoints_and_lookups_success_lookups_required(
     for endpoint in collection.endpoint.entries:
         assert endpoint.get("entry-date", None) is not None
         assert endpoint.get("entry-date", None) == expected_entry_date
+
+
+def test_command_add_endpoints_and_lookups_considers_organisation(
+    capfd,
+    endpoint_url_csv,
+    collection_dir,
+    pipeline_dir,
+    specification_dir,
+    organisation_path,
+    mocker,
+    mock_resource_identifical_reference,
+):
+    with open(mock_resource_identifical_reference, "r", encoding="utf-8") as f:
+        csv_content = f.read().encode("utf-8")
+
+    collection_name = "ancient-woodland"
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.request.headers = {"test": "test"}
+    mock_response.headers = {"test": "test"}
+    mock_response.content = csv_content
+    mocker.patch(
+        "requests.Session.get",
+        return_value=mock_response,
+    )
+    add_endpoints_and_lookups(
+        csv_file_path=endpoint_url_csv,
+        collection_name=collection_name,
+        collection_dir=Path(collection_dir),
+        specification_dir=specification_dir,
+        organisation_path=organisation_path,
+        pipeline_dir=pipeline_dir,
+    )
+
+    # test lookups have been added correctly
+    lookups = Lookups(pipeline_dir)
+    lookups.load_csv()
+
+    out = capfd.readouterr()
+
+    assert len(lookups.entries) > 0
+    assert (
+        "ancient-woodland , government-organisation:D1342 , ABC_0001 , 110000001"
+        in out[0]
+    )
 
 
 def test_cli_add_endpoints_and_lookups_cmd_success_return_code(


### PR DESCRIPTION
Currently, the pipeline assigns entities based on prefix and reference matching without considering organisation. This can result in instances where different organisations may share common entities when their references match.

When references match across organizations, the command currently fails to treat the entities of the second organization as new.

The reason being load_lookups() function includes entries that only have a prefix and reference. 
This PR updates the function to add lookups only when entry_number is present, thereby excluding entries with only two fields (prefix and reference).

The test makes sure that the entry with same existing reference is added when the organisation is different.