### PR TITLE
Handle unhashable content.

### DIFF
--- a/digital_land/collect.py
+++ b/digital_land/collect.py
@@ -159,14 +159,21 @@ class Collector:
 
         log["elapsed"] = str(round(timer() - start, 3))
 
-        if content:
-            status = FetchStatus.OK
-            log["resource"] = self.save_content(content)
-        else:
-            status = FetchStatus.FAILED
+        status = self.save_resource(content, log_path, log)
 
         self.save_log(log_path, log)
         return status
+
+    def save_resource(self, content, url, log):
+        if content:
+            try:
+                log["resource"] = self.save_content(content)
+                return FetchStatus.OK
+            except Exception as exception:
+                logging.warning(f"Failed to save data from '{url} ({exception})")
+                log["exception"] = type(exception).__name__
+
+        return FetchStatus.FAILED
 
     def collect(self, endpoint_path):
         for row in csv.DictReader(open(endpoint_path, newline="")):

--- a/tests/unit/test_collect.py
+++ b/tests/unit/test_collect.py
@@ -138,3 +138,23 @@ def test_strip_timestamp(collector, tmp_path):
 
     log_content = read_log(collector, url)
     assert log_content["resource"] == expected_hash
+
+
+def test_save_resource(collector, tmp_path):
+    log = {}
+    url = "http://some.url"
+    status = collector.save_resource(b"some data", url, log)
+
+    assert status == FetchStatus.OK
+    output_path = tmp_path / f"resource/{sha_digest('some data')}"
+    assert os.path.isfile(output_path)
+    assert open(output_path).read() == "some data"
+
+
+def test_resource_not_bytes(collector):
+    log = {}
+    url = "http://other.url"
+    status = collector.save_resource("Unicode data", url, log)
+
+    assert status == FetchStatus.FAILED
+    assert log["exception"] == "TypeError"


### PR DESCRIPTION
Log errors generating hash from content, rather than crashing.