### PR TITLE
Adjust LookupPhase to include organisation while assigning lookups

### DIFF
--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -57,11 +57,21 @@ class LookupPhase(Phase):
                 organisation=organisation,
                 reference=reference,
             )
+        )
+        if not entity:
             # TBD this needs to specifically not match unless the organisation and other columns
             # are empty in the lookups.csv probably isn't a change here.
             # or by the CURIE
-            or self.lookup(prefix=prefix, reference=reference)
-        )
+            entity = self.lookup(prefix=prefix, reference=reference)
+
+            if entity in self.lookups.values():
+                associated_keys = [
+                    key for key, value in self.lookups.items() if value == entity
+                ]
+                for key in associated_keys:
+                    parts = key.split(",")
+                    if len(parts) > 3 and parts[3]:
+                        entity = ""
 
         return entity
 

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -73,7 +73,14 @@ class LookupPhase(Phase):
                 ]
                 for key in associated_keys:
                     parts = key.split(",")
-                    if len(parts) > 3 and parts[3]:
+                    if (
+                        len(parts) > 3
+                        and parts[3]
+                        and any(
+                            value in parts[3]
+                            for value in ["authority", "development", "government"]
+                        )
+                    ):
                         entity = ""
 
         return entity

--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -64,6 +64,9 @@ class LookupPhase(Phase):
             # or by the CURIE
             entity = self.lookup(prefix=prefix, reference=reference)
 
+            # When obtaining an entity number using only the prefix and reference, check if the
+            # lookup includes an associated organisation. If it does, do not use the entity number,
+            # as it is organisation specific.
             if entity in self.lookups.values():
                 associated_keys = [
                     key for key, value in self.lookups.items() if value == entity

--- a/tests/e2e/test_add_endpoints_and_lookups.py
+++ b/tests/e2e/test_add_endpoints_and_lookups.py
@@ -549,7 +549,7 @@ def test_command_add_endpoints_and_lookups_considers_organisation(
     out = capfd.readouterr()
 
     # assert to verify new lookup with the same reference is added
-    assert len(lookups.entries) > 0
+    assert len(lookups.entries) == 2
     assert (
         "ancient-woodland , government-organisation:D1342 , ABC_0001 , 110000001"
         in out[0]


### PR DESCRIPTION
Ref: https://trello.com/c/klA9yNSh/1297-redo-adjust-pipeline-to-include-organisation-while-assigning-entities

For a new entity if a lookup with the same reference exists then pipeline doesnt seem to add a new lookup for the new entity as it considers it as already existing even when they belong to different organisation.

This PR updates the get_entity() of LookupPhase to check the entity number obtained using prefix and reference, it checks if an organisation is associated with the existing lookup if yes then it creates a new lookups for the incoming entity.