### PR TITLE
Negative integer decimal issue

### DIFF
--- a/digital_land/datatype/factory.py
+++ b/digital_land/datatype/factory.py
@@ -8,14 +8,16 @@ from .multipolygon import MultiPolygonDataType
 from .point import PointDataType
 from .string import StringDataType
 from .uri import URIDataType
+from .latitude import LatitudeDataType
+from .longitude import LongitudeDataType
 
 
 def datatype_factory(datatype_name):
     typemap = {
         "integer": IntegerDataType,
         "decimal": DecimalDataType,
-        "latitude": DecimalDataType,
-        "longitude": DecimalDataType,
+        "latitude": LatitudeDataType,
+        "longitude": LongitudeDataType,
         "string": StringDataType,
         "address": AddressDataType,
         "text": StringDataType,  # TODO do we need dedicated type for Text?

--- a/digital_land/datatype/latitude.py
+++ b/digital_land/datatype/latitude.py
@@ -15,7 +15,6 @@ class LatitudeDataType(DataType):
     def normalise(self, value, issues=None):
         # remove commas ..
         value = value.replace(",", "")
-        value = value.replace("£", "")
 
         try:
             d = Decimal(value)

--- a/digital_land/datatype/latitude.py
+++ b/digital_land/datatype/latitude.py
@@ -1,0 +1,53 @@
+from decimal import Decimal, InvalidOperation
+from .datatype import DataType
+
+
+class LatitudeDataType(DataType):
+    def __init__(self, precision=6, minimum=None, maximum=None):
+        self.precision = precision
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def format(self, value):
+        rounded_value = round(Decimal(value), self.precision).normalize()
+        return str(self.remove_exponent(rounded_value))
+
+    def normalise(self, value, issues=None):
+        # remove commas ..
+        value = value.replace(",", "")
+        value = value.replace("£", "")
+
+        try:
+            d = Decimal(value)
+        except InvalidOperation:
+            if issues:
+                issues.log(
+                    "invalid decimal",
+                    value,
+                    f"{issues.fieldname} must be a decimal number",
+                )
+            return ""
+
+        if self.minimum is not None and d < self.minimum:
+            if issues:
+                issues.log(
+                    "too small",
+                    value,
+                    f"{issues.fieldname} must be larger than {self.minimum}",
+                )
+            return ""
+
+        if self.maximum is not None and d > self.maximum:
+            if issues:
+                issues.log(
+                    "too large",
+                    value,
+                    f"{issues.fieldname} must be lower than {self.maximum}",
+                )
+            return ""
+
+        return self.format(d)
+
+    # taken from FAQs in decimal documentation
+    def remove_exponent(self, d):
+        return d.quantize(Decimal(1)) if d == d.to_integral() else d.normalize()

--- a/digital_land/datatype/longitude.py
+++ b/digital_land/datatype/longitude.py
@@ -1,0 +1,53 @@
+from decimal import Decimal, InvalidOperation
+from .datatype import DataType
+
+
+class LongitudeDataType(DataType):
+    def __init__(self, precision=6, minimum=None, maximum=None):
+        self.precision = precision
+        self.minimum = minimum
+        self.maximum = maximum
+
+    def format(self, value):
+        rounded_value = round(Decimal(value), self.precision).normalize()
+        return str(self.remove_exponent(rounded_value))
+
+    def normalise(self, value, issues=None):
+        # remove commas ..
+        value = value.replace(",", "")
+        value = value.replace("£", "")
+
+        try:
+            d = Decimal(value)
+        except InvalidOperation:
+            if issues:
+                issues.log(
+                    "invalid decimal",
+                    value,
+                    f"{issues.fieldname} must be a decimal number",
+                )
+            return ""
+
+        if self.minimum is not None and d < self.minimum:
+            if issues:
+                issues.log(
+                    "too small",
+                    value,
+                    f"{issues.fieldname} must be larger than {self.minimum}",
+                )
+            return ""
+
+        if self.maximum is not None and d > self.maximum:
+            if issues:
+                issues.log(
+                    "too large",
+                    value,
+                    f"{issues.fieldname} must be lower than {self.maximum}",
+                )
+            return ""
+
+        return self.format(d)
+
+    # taken from FAQs in decimal documentation
+    def remove_exponent(self, d):
+        return d.quantize(Decimal(1)) if d == d.to_integral() else d.normalize()

--- a/digital_land/datatype/longitude.py
+++ b/digital_land/datatype/longitude.py
@@ -15,7 +15,6 @@ class LongitudeDataType(DataType):
     def normalise(self, value, issues=None):
         # remove commas ..
         value = value.replace(",", "")
-        value = value.replace("£", "")
 
         try:
             d = Decimal(value)

--- a/tests/unit/datatype/test_latitude.py
+++ b/tests/unit/datatype/test_latitude.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env pytest
+
+from digital_land.log import IssueLog
+from digital_land.datatype.latitude import LatitudeDataType
+
+
+def test_decimal_normalise():
+    issues = IssueLog()
+    latitude = LatitudeDataType()
+
+    assert latitude.normalise("257267") == "257267"
+
+    assert latitude.normalise("-1") == "-1"
+    assert latitude.normalise("-3.77687") == "-3.77687"
+
+    assert latitude.normalise("1200.00") == "1200"
+    assert latitude.normalise("1,200.00") == "1200"
+
+    assert latitude.normalise("foo", issues=issues) == ""
+    issue = issues.rows.pop()
+    assert issue["issue-type"] == "invalid decimal"
+    assert issue["value"] == "foo"
+    assert issues.rows == []

--- a/tests/unit/datatype/test_longitude.py
+++ b/tests/unit/datatype/test_longitude.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env pytest
+
+from digital_land.log import IssueLog
+from digital_land.datatype.longitude import LongitudeDataType
+
+
+def test_decimal_normalise():
+    issues = IssueLog()
+    longitude = LongitudeDataType()
+
+    assert longitude.normalise("545764") == "545764"
+
+    assert longitude.normalise("-1") == "-1"
+    assert longitude.normalise("-1.123456789") == "-1.123457"
+
+    assert longitude.normalise("1200.00") == "1200"
+    assert longitude.normalise("1,200.00") == "1200"
+
+    assert longitude.normalise("foo", issues=issues) == ""
+    issue = issues.rows.pop()
+    assert issue["issue-type"] == "invalid decimal"
+    assert issue["value"] == "foo"
+    assert issues.rows == []


### PR DESCRIPTION
Reference ticket: https://trello.com/c/vV815COa/3285-new-issuetype-check-that-numeric-fields-are-not-negative

After adding the "too small" issue type to check for negative values in integer and decimal fields, geoX and geoY began triggering "too small" error because they were mapped to DecimalDataType. 
To resolve this, I created separate data types for Latitude and Longitude.