### PR TITLE
adjust how logs are loaded to allow for custom paths to logs

### DIFF
--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -122,6 +122,7 @@ def convert_cmd(input_path, output_path):
 @organisation_path
 @column_field_dir
 @dataset_resource_dir
+@issue_dir
 @click.argument("input-paths", nargs=-1, type=click.Path(exists=True))
 @click.pass_context
 def dataset_create_cmd(
@@ -131,6 +132,7 @@ def dataset_create_cmd(
     organisation_path,
     column_field_dir,
     dataset_resource_dir,
+    issue_dir,
 ):
     return dataset_create(
         input_paths=input_paths,
@@ -141,6 +143,7 @@ def dataset_create_cmd(
         specification=ctx.obj["SPECIFICATION"],
         column_field_dir=column_field_dir,
         dataset_resource_dir=dataset_resource_dir,
+        issue_dir=issue_dir,
     )
 
 

--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -103,9 +103,8 @@ def collection_pipeline_makerules_cmd(collection_dir):
 
 @cli.command("collection-save-csv", short_help="save collection as CSV package")
 @collection_dir
-@organisation_path
-def collection_save_csv_cmd(collection_dir, organisation_path):
-    return collection_save_csv(collection_dir, organisation_path)
+def collection_save_csv_cmd(collection_dir):
+    return collection_save_csv(collection_dir)
 
 
 #

--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -175,6 +175,7 @@ def dataset_dump_flattened_cmd(ctx, input_path, output_path):
 @column_field_dir
 @dataset_resource_dir
 @organisation_path
+@collection_dir
 @click.pass_context
 def pipeline_command(
     ctx,
@@ -189,6 +190,7 @@ def pipeline_command(
     organisations,
     entry_date,
     custom_temp_dir,
+    collection_dir,
 ):
     dataset = ctx.obj["DATASET"]
     pipeline = ctx.obj["PIPELINE"]
@@ -203,6 +205,7 @@ def pipeline_command(
         specification,
         input_path,
         output_path,
+        collection_dir=collection_dir,
         issue_dir=issue_dir,
         column_field_dir=column_field_dir,
         dataset_resource_dir=dataset_resource_dir,

--- a/digital_land/cli.py
+++ b/digital_land/cli.py
@@ -103,8 +103,9 @@ def collection_pipeline_makerules_cmd(collection_dir):
 
 @cli.command("collection-save-csv", short_help="save collection as CSV package")
 @collection_dir
-def collection_save_csv_cmd(collection_dir):
-    return collection_save_csv(collection_dir)
+@organisation_path
+def collection_save_csv_cmd(collection_dir, organisation_path):
+    return collection_save_csv(collection_dir, organisation_path)
 
 
 #
@@ -118,10 +119,19 @@ def convert_cmd(input_path, output_path):
 
 @cli.command("dataset-create", short_help="create a dataset from processed resources")
 @click.option("--output-path", type=click.Path(), default=None, help="sqlite3 path")
-@click.argument("input-paths", nargs=-1, type=click.Path(exists=True))
 @organisation_path
+@column_field_dir
+@dataset_resource_dir
+@click.argument("input-paths", nargs=-1, type=click.Path(exists=True))
 @click.pass_context
-def dataset_create_cmd(ctx, input_paths, output_path, organisation_path):
+def dataset_create_cmd(
+    ctx,
+    input_paths,
+    output_path,
+    organisation_path,
+    column_field_dir,
+    dataset_resource_dir,
+):
     return dataset_create(
         input_paths=input_paths,
         output_path=output_path,
@@ -129,6 +139,8 @@ def dataset_create_cmd(ctx, input_paths, output_path, organisation_path):
         pipeline=ctx.obj["PIPELINE"],
         dataset=ctx.obj["DATASET"],
         specification=ctx.obj["SPECIFICATION"],
+        column_field_dir=column_field_dir,
+        dataset_resource_dir=dataset_resource_dir,
     )
 
 

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -160,7 +160,7 @@ def pipeline_run(
     specification,
     input_path,
     output_path,
-    collection_dir="./collection",  # TBD: remove, replaced by endpoints, organisations and entry_date
+    collection_dir,  # TBD: remove, replaced by endpoints, organisations and entry_date
     null_path=None,  # TBD: remove this
     issue_dir=None,
     organisation_path=None,

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -76,10 +76,8 @@ def collection_list_resources(collection_dir):
         print(resource_path(resource, directory=collection_dir))
 
 
-def collection_pipeline_makerules(collection_dir, org_path):
-    collection = Collection(
-        name=None, directory=collection_dir, organisation_path=org_path
-    )
+def collection_pipeline_makerules(collection_dir):
+    collection = Collection(name=None, directory=collection_dir)
     collection.load()
     collection.pipeline_makerules()
 
@@ -194,7 +192,9 @@ def pipeline_run(
     redirect_lookups = pipeline.redirect_lookups()
 
     # load organisations
-    organisation = Organisation(organisation_path, Path(pipeline.path))
+    organisation = Organisation(
+        organisation_path=organisation_path, pipeline_dir=Path(pipeline.path)
+    )
 
     # load the resource default values from the collection
     if not endpoints:
@@ -307,7 +307,9 @@ def dataset_create(
     # Set up initial objects
     column_field_dir = Path(column_field_dir)
     dataset_resource_dir = Path(dataset_resource_dir)
-    organisation = Organisation(organisation_path, Path(pipeline.path))
+    organisation = Organisation(
+        organisation_path=organisation_path, pipeline_dir=Path(pipeline.path)
+    )
     package = DatasetPackage(
         dataset,
         organisation=organisation,
@@ -731,7 +733,9 @@ def get_resource_unidentified_lookups(
     schema = specification.pipeline[pipeline.name]["schema"]
 
     # organisation phase
-    organisation = Organisation(org_csv_path, Path(pipeline.path))
+    organisation = Organisation(
+        organisation_path=org_csv_path, pipeline_dir=Path(pipeline.path)
+    )
 
     # print lookups phase
     pipeline_lookups = pipeline.lookups()

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -76,8 +76,10 @@ def collection_list_resources(collection_dir):
         print(resource_path(resource, directory=collection_dir))
 
 
-def collection_pipeline_makerules(collection_dir):
-    collection = Collection(name=None, directory=collection_dir)
+def collection_pipeline_makerules(collection_dir, org_path):
+    collection = Collection(
+        name=None, directory=collection_dir, organisation_path=org_path
+    )
     collection.load()
     collection.pipeline_makerules()
 
@@ -295,10 +297,16 @@ def dataset_create(
     dataset,
     specification,
     issue_dir="issue",
+    column_field_dir="var/column-field",
+    dataset_resource_dir="var/dataset-resource",
 ):
     if not output_path:
         print("missing output path", file=sys.stderr)
         sys.exit(2)
+
+    # Set up initial objects
+    column_field_dir = Path(column_field_dir)
+    dataset_resource_dir = Path(dataset_resource_dir)
     organisation = Organisation(organisation_path, Path(pipeline.path))
     package = DatasetPackage(
         dataset,
@@ -308,7 +316,10 @@ def dataset_create(
     )
     package.create()
     for path in input_paths:
+        path_obj = Path(path)
         package.load_transformed(path)
+        package.load_column_fields(column_field_dir / dataset / path_obj.name)
+        package.load_dataset_resource(dataset_resource_dir / dataset / path_obj.name)
     package.load_entities()
 
     old_entity_path = os.path.join(pipeline.path, "old-entity.csv")

--- a/digital_land/organisation.py
+++ b/digital_land/organisation.py
@@ -22,7 +22,7 @@ class Organisation:
     organisation_uri = {}
     organisation_lookup = {}
 
-    def __init__(self, organisation_path=None, pipeline_dir=None, organisation=None):
+    def __init__(self, organisation_path, pipeline_dir, organisation=None):
         if organisation_path:
             self.organisation_path = organisation_path
         if pipeline_dir:

--- a/digital_land/organisation.py
+++ b/digital_land/organisation.py
@@ -22,7 +22,7 @@ class Organisation:
     organisation_uri = {}
     organisation_lookup = {}
 
-    def __init__(self, organisation_path, pipeline_dir, organisation=None):
+    def __init__(self, organisation_path=None, pipeline_dir=None, organisation=None):
         if organisation_path:
             self.organisation_path = organisation_path
         if pipeline_dir:

--- a/digital_land/package/dataset.py
+++ b/digital_land/package/dataset.py
@@ -1,7 +1,6 @@
 import csv
 import json
 import logging
-import re
 from decimal import Decimal
 
 import shapely.wkt
@@ -243,17 +242,20 @@ class DatasetPackage(SqlitePackage):
             self.insert("fact-resource", fact_resource_fields, row, upsert=True)
 
     def load_column_fields(self, path):
-        m = re.search(r"/([a-f0-9]+).csv$", path)
-        resource = m.group(1)
 
         fields = self.specification.schema["column-field"]["fields"]
 
         logging.info(f"loading column_fields from {path}")
 
+        self.connect()
+        self.create_cursor()
         for row in csv.DictReader(open(path, newline="")):
-            row["resource"] = resource
+            row["resource"] = path.stem
             row["dataset"] = self.dataset
             self.insert("column-field", fields, row)
+
+        self.commit()
+        self.disconnect()
 
     def load_issues(self, path):
         self.connect()
@@ -271,8 +273,13 @@ class DatasetPackage(SqlitePackage):
 
         logging.info(f"loading dataset-resource from {path}")
 
+        self.connect()
+        self.create_cursor()
         for row in csv.DictReader(open(path, newline="")):
             self.insert("dataset-resource", fields, row)
+
+        self.commit()
+        self.disconnect()
 
     def load_transformed(self, path):
 

--- a/digital_land/package/dataset.py
+++ b/digital_land/package/dataset.py
@@ -242,7 +242,10 @@ class DatasetPackage(SqlitePackage):
             )
             self.insert("fact-resource", fact_resource_fields, row, upsert=True)
 
-    def load_column_fields(self, path, resource):
+    def load_column_fields(self, path):
+        m = re.search(r"/([a-f0-9]+).csv$", path)
+        resource = m.group(1)
+
         fields = self.specification.schema["column-field"]["fields"]
 
         logging.info(f"loading column_fields from {path}")
@@ -263,7 +266,7 @@ class DatasetPackage(SqlitePackage):
         self.commit()
         self.disconnect()
 
-    def load_dataset_resource(self, path, resource):
+    def load_dataset_resource(self, path):
         fields = self.specification.schema["dataset-resource"]["fields"]
 
         logging.info(f"loading dataset-resource from {path}")
@@ -272,19 +275,10 @@ class DatasetPackage(SqlitePackage):
             self.insert("dataset-resource", fields, row)
 
     def load_transformed(self, path):
-        m = re.search(r"/([a-f0-9]+).csv$", path)
-        resource = m.group(1)
 
         self.connect()
         self.create_cursor()
         self.load_facts(path)
-        # self.load_issues(path.replace("transformed/", "issue/"), resource)
-        self.load_column_fields(
-            path.replace("transformed/", "var/column-field/"), resource
-        )
-        self.load_dataset_resource(
-            path.replace("transformed/", "var/dataset-resource/"), resource
-        )
         self.commit()
         self.disconnect()
 

--- a/tests/integration/package/test_dataset.py
+++ b/tests/integration/package/test_dataset.py
@@ -145,7 +145,9 @@ def test_load_old_entities_entities_outside_of_range_are_removed(tmp_path):
     }
 
     specification = Specification(schema=schema, field=field)
-    organisation = Organisation(organisation={})
+    organisation = Organisation(
+        organisation_path=None, pipeline_dir=None, organisation={}
+    )
 
     # write data to csv as we only seem to load from csv
     data = [
@@ -216,7 +218,8 @@ def test_entry_date_upsert_uploads_newest_date(
     sqlite3_path = os.path.join(tmp_path, f"{dataset}.sqlite3")
 
     organisation = Organisation(
-        organisation_csv, Path(os.path.dirname(blank_patch_csv))
+        organisation_path=organisation_csv,
+        pipeline_dir=Path(os.path.dirname(blank_patch_csv)),
     )
     package = DatasetPackage(
         "conservation-area",
@@ -316,7 +319,9 @@ def test_load_issues_uploads_issues_from_csv(tmp_path):
     }
 
     specification = Specification(schema=schema, field=field)
-    organisation = Organisation(organisation={})
+    organisation = Organisation(
+        organisation_path=None, pipeline_dir=None, organisation={}
+    )
 
     # write data to csv as we only seem to load from csv
     data = [
@@ -380,7 +385,8 @@ def test_entry_date_upsert_uploads_blank_fields(
     sqlite3_path = os.path.join(tmp_path, f"{dataset}.sqlite3")
 
     organisation = Organisation(
-        organisation_csv, Path(os.path.dirname(blank_patch_csv))
+        organisation_path=organisation_csv,
+        pipeline_dir=Path(os.path.dirname(blank_patch_csv)),
     )
     package = DatasetPackage(
         "conservation-area",

--- a/tests/integration/test_organisation.py
+++ b/tests/integration/test_organisation.py
@@ -6,7 +6,8 @@ import logging
 class TestOrganisation:
     def test_organisation_lookup(self):
         organisation = Organisation(
-            organisation_path="tests/data/listed-building/organisation.csv"
+            organisation_path="tests/data/listed-building/organisation.csv",
+            pipeline_dir=None,
         )
 
         assert organisation.lookup("Borchester") == ""
@@ -68,7 +69,8 @@ class TestOrganisation:
             logging.warning(type(org_match))
             dictwriter.writerow(org_match)
         organisation = Organisation(
-            organisation_path="tests/data/listed-building/organisation.csv"
+            organisation_path="tests/data/listed-building/organisation.csv",
+            pipeline_dir=None,
         )
         assert (
             organisation.lookup("local-authority-eng:BRW") == "local-authority-eng:BRW"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current dataset-create command needs the transformed files, column field logs and dataset resource logs to all be in the default folders to work. This needs fixing to allow the data management team to run collections directly in the config repo

## Related Tickets & Documents
- [Ticket Link](https://trello.com/c/kS9sGFlo/3468-allow-collection-to-be-run-locally-from-the-config-repo?filter=label:Infrastructure)


## QA Instructions, Screenshots, Recordings

* Run automated tests
* Run brnach on a local repository to ensure it doesn't break anythinng

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: Existing tests to show changes don't break command internals.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

* Ensure the next nightly run works 
