### PR TITLE
Updates get_max_entity() to handle distinct prefix value

### DIFF
--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -702,7 +702,7 @@ def assign_entities(
             lookups.add_entry(entry[0])
 
     # save edited csvs
-    max_entity_num = lookups.get_max_entity(pipeline_name)
+    max_entity_num = lookups.get_max_entity(pipeline_name, specification)
     lookups.entity_num_gen.state["current"] = max_entity_num
     lookups.entity_num_gen.state["range_max"] = specification.get_dataset_entity_max(
         pipeline_name

--- a/digital_land/pipeline.py
+++ b/digital_land/pipeline.py
@@ -451,18 +451,20 @@ class Lookups:
         for row in reader:
             self.add_entry(row, is_new_entry=False)
 
-    def get_max_entity(self, prefix) -> int:
+    def get_max_entity(self, prefix, specification) -> int:
         if len(self.entries) == 0:
             return 0
         if not prefix:
             return 0
 
+        dataset_prefix = specification.dataset_prefix(prefix)
         try:
             ret_val = max(
                 [
                     int(entry["entity"])
                     for entry in self.entries
-                    if (entry["prefix"] == prefix) and (entry.get("entity", None))
+                    if (entry["prefix"] == prefix or entry["prefix"] == dataset_prefix)
+                    and (entry.get("entity", None))
                 ]
             )
             return ret_val

--- a/tests/data/specification/dataset.csv
+++ b/tests/data/specification/dataset.csv
@@ -1,6 +1,8 @@
-dataset,name,text,typology
-dataset-one,"First Dataset","Text of first dataset",
-dataset-two,"Second Dataset","Text of first dataset",
-dataset-three,"Third Dataset","Text of third dataset",
-tree-preservation-zone-type,"Types of zone covered by the tree preservation order","Tree preservation zone type",category
-conservation-area-document-type,,"Conservation area document type",category
+dataset,name,text,typology,prefix
+dataset-one,"First Dataset","Text of first dataset",,
+dataset-two,"Second Dataset","Text of first dataset",,
+dataset-three,"Third Dataset","Text of third dataset",,
+tree-preservation-zone-type,"Types of zone covered by the tree preservation order","Tree preservation zone type",category,
+conservation-area-document-type,,"Conservation area document type",category,
+parish,,,,statistical-geography
+ancient-woodland,,,,

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -2,6 +2,7 @@
 import pytest
 from digital_land.pipeline import Pipeline
 from digital_land.pipeline import Lookups
+from digital_land.specification import Specification
 from pathlib import Path
 from unittest.mock import mock_open, patch
 
@@ -129,7 +130,9 @@ class TestPipeLine:
 
         pipeline_name = "ancient-woodland"
         lookups = Lookups("")
-        max_entity_num = lookups.get_max_entity(pipeline_name)
+
+        specification = Specification("tests/data/specification/")
+        max_entity_num = lookups.get_max_entity(pipeline_name, specification)
 
         assert max_entity_num == 0
 
@@ -143,14 +146,44 @@ class TestPipeLine:
         lookups.entries.append(entry)
         expected_entity_num = 12344
 
-        assert lookups.get_max_entity(pipeline_name) == expected_entity_num
+        assert (
+            lookups.get_max_entity(pipeline_name, specification) == expected_entity_num
+        )
 
-        max_entity_num = lookups.get_max_entity(pipeline_name)
+        max_entity_num = lookups.get_max_entity(pipeline_name, specification)
         lookups.entity_num_gen.state["current"] = max_entity_num
         lookups.entity_num_gen.state["range_max"] = max_entity_num + 10
         expected_entity_num = 12345
 
         assert lookups.entity_num_gen.next() == expected_entity_num
+
+    def test_lookups_get_max_entity_with_distinct_prefix(self):
+        """
+        test entity num generation functionality when prefix value differs from dataset value
+        :return:
+        """
+
+        pipeline_name = "parish"
+        lookups = Lookups("")
+
+        specification = Specification("tests/data/specification/")
+        max_entity_num = lookups.get_max_entity(pipeline_name, specification)
+
+        assert max_entity_num == 0
+
+        entry = {
+            "prefix": "statistical-geography",
+            "resource": "",
+            "organisation": "government-organisation:D1342",
+            "reference": "1",
+            "entity": "1000",
+        }
+        lookups.entries.append(entry)
+        expected_entity_num = 1000
+
+        assert (
+            lookups.get_max_entity(pipeline_name, specification) == expected_entity_num
+        )
 
     def test_lookups_validate_entry_success(self):
         """

--- a/tests/unit/test_specification.py
+++ b/tests/unit/test_specification.py
@@ -13,6 +13,8 @@ def test_dataset_names():
         "dataset-three",
         "tree-preservation-zone-type",
         "conservation-area-document-type",
+        "parish",
+        "ancient-woodland",
     ]
 
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The add_endpoints script currently adds lookups starting from the first entity number when the prefix name for a dataset differs from the actual dataset name. This PR addresses the issue by allowing the script to accept the prefix name and correctly assigns lookups using the max entity number.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- Ticket Link https://dluhcdigital.atlassian.net/jira/software/projects/DATA/boards/229?selectedIssue=DATA-841
- Related Issue https://github.com/digital-land/config/commit/7261175af5edadf4432d449ea1fcd2a91ccefbfd
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?