### PR TITLE
Saving log parquet bug fixes

### DIFF
--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -47,12 +47,18 @@ class Log:
             # Define the schema, using strings for non '-number' field
             schema = pa.schema(
                 [
-                    (field, pa.int16() if "number" in field else pa.string())
+                    (field, pa.int64() if "number" in field else pa.string())
                     for field in self.fieldnames
                 ]
             )
             if len(self.rows) > 0:
-                table = pa.Table.from_pylist(self.rows, schema=schema)
+                formatted_rows = self.rows.copy()
+                for i, log in enumerate(formatted_rows):
+                    formatted_rows[i] = {
+                        key: log[key] if "number" in key else str(log[key])
+                        for key in log
+                    }
+                table = pa.Table.from_pylist(formatted_rows, schema=schema)
             else:
                 rows = [pa.array([], type=field.type) for field in schema]
                 table = pa.Table.from_arrays(rows, schema=schema)

--- a/digital_land/log.py
+++ b/digital_land/log.py
@@ -47,7 +47,7 @@ class Log:
             # Define the schema, using strings for non '-number' field
             schema = pa.schema(
                 [
-                    (field, pa.int64() if "number" in field else pa.string())
+                    (field, pa.uint32() if "number" in field else pa.string())
                     for field in self.fieldnames
                 ]
             )

--- a/tests/integration/test_log.py
+++ b/tests/integration/test_log.py
@@ -222,3 +222,96 @@ def test_log_save_parquet_no_rows(tmp_path_factory):
     conn = duckdb.connect()
     df = conn.execute(f"SELECT * FROM '{parquet_path}'").df()
     assert (set(df.columns) - set(fieldnames)) == set()
+
+
+def test_log_save_parquet_large_int(tmp_path_factory):
+    dataset = "listed-building-outline"
+    resource = "resource"
+    fieldnames = ["dataset", "resource", "issue", "entry-number"]
+
+    log = Log()
+    log.dataset = dataset
+    log.resource = resource
+    log.fieldnames = fieldnames
+
+    log.rows = [
+        {
+            "dataset": dataset,
+            "resource": resource,
+            "issue": "issue1",
+            "entry-number": 33281,
+        },
+    ]
+
+    output_dir = tmp_path_factory.mktemp("output")
+
+    log.save_parquet(output_dir)
+
+    parquet_path = os.path.join(
+        output_dir, f"dataset={dataset}/resource={resource}/{resource}.parquet"
+    )
+    assert os.path.isfile(parquet_path)
+    conn = duckdb.connect()
+    df = conn.execute(f"SELECT * FROM '{parquet_path}'").df()
+    assert (set(df.iloc[0].values) - set([dataset, resource, "issue1", 33281])) == set()
+    assert (set(df.columns) - set(fieldnames)) == set()
+
+
+def test_log_save_parquet_non_string(tmp_path_factory):
+    dataset = "listed-building-outline"
+    resource = "resource"
+    fieldnames = ["dataset", "resource", "issue", "value"]
+
+    log = Log()
+    log.dataset = dataset
+    log.resource = resource
+    log.fieldnames = fieldnames
+
+    log.rows = [
+        {
+            "dataset": dataset,
+            "resource": resource,
+            "issue": "issue1",
+            "value": 1,
+        },
+        {
+            "dataset": dataset,
+            "resource": resource,
+            "issue": "issue2",
+            "value": ["list", "here"],
+        },
+        {
+            "dataset": dataset,
+            "resource": resource,
+            "issue": "issue3",
+            "value": 1.2,
+        },
+        {
+            "dataset": dataset,
+            "resource": resource,
+            "issue": "issue4",
+            "value": {"python": "dict"},
+        },
+    ]
+
+    output_dir = tmp_path_factory.mktemp("output")
+
+    log.save_parquet(output_dir)
+
+    parquet_path = os.path.join(
+        output_dir, f"dataset={dataset}/resource={resource}/{resource}.parquet"
+    )
+    assert os.path.isfile(parquet_path)
+    conn = duckdb.connect()
+    df = conn.execute(f"SELECT * FROM '{parquet_path}'").df()
+    print(df.iloc[1].values)
+    assert (set(df.iloc[0].values) - set([dataset, resource, "issue1", "1"])) == set()
+    assert (
+        set(df.iloc[1].values) - set([dataset, resource, "issue2", "['list', 'here']"])
+    ) == set()
+    assert (set(df.iloc[2].values) - set([dataset, resource, "issue3", "1.2"])) == set()
+    assert (
+        set(df.iloc[3].values)
+        - set([dataset, resource, "issue4", "{'python': 'dict'}"])
+    ) == set()
+    assert (set(df.columns) - set(fieldnames)) == set()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes two bugs in the save_parquet method for the Log class:
- Uses a larger integer datatype for the pyarrow Table, as this was causing some collections to crash
- Formats rows in the log to string type (where applicable). The pyarrow schema is expecting strings for most columns, but when the Table is created no coercion occurs so there were some cases where a non string was being passed in

## Related Tickets & Documents

- Ticket Link https://github.com/orgs/digital-land/projects/9/views/3?pane=issue&itemId=83945009&issue=digital-land%7Cdigital-land-python%7C262
- Related Issue #262


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests