### PR TITLE
adds replacement field to get_valid_category_values

### DIFF
--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -281,7 +281,7 @@ def pipeline_run(
         entry_date = collection.resource_start_date(resource)
 
     # Load valid category values
-    valid_category_values = api.get_valid_category_values(dataset)
+    valid_category_values = api.get_valid_category_values(dataset, pipeline)
 
     # resource specific default values
     if len(organisations) == 1:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,8 +1,12 @@
+import csv
+import os
 from digital_land.api import API
 from unittest.mock import Mock, mock_open
 import pytest
 from requests import Response, RequestException
 from os import stat_result
+
+from digital_land.pipeline.main import Pipeline
 
 _tpz_type_data = b"""dataset,end-date,entity,entry-date,geojson,geometry,name,organisation-entity,point,prefix,reference,start-date,typology,description,notes
 tree-preservation-zone-type,,18100000,2023-09-11,,,Area,600001,,tree-preservation-zone-type,area,2023-09-11,category,,
@@ -18,6 +22,26 @@ conservation-area-document-type,,4210003,2024-05-20,,,Area map,600001,,conservat
 _stat_result_empty = stat_result((0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
 _stat_result_tpzt = stat_result((0, 0, 0, 0, 0, 0, len(_tpz_type_data), 0, 0, 0))
 _stat_result_cadt = stat_result((0, 0, 0, 0, 0, 0, len(_cad_type_data), 0, 0, 0))
+
+
+@pytest.fixture
+def pipeline_dir(tmp_path_factory):
+    pipeline_dir = tmp_path_factory.mktemp("pipeline")
+
+    row = {
+        "dataset": "conservation-area-document",
+        "field": "DocumentType",
+        "replacement-field": "document-type",
+    }
+
+    fieldnames = row.keys()
+
+    with open(os.path.join(pipeline_dir, "transform.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=fieldnames)
+        dictwriter.writeheader()
+        dictwriter.writerow(row)
+
+    return pipeline_dir
 
 
 class MockSpecification:
@@ -88,7 +112,7 @@ def test_download_dataset_error(mocker):
         api.download_dataset("test")
 
 
-def test_get_categorical_field_values_download(mocker):
+def test_get_categorical_field_values_download(mocker, pipeline_dir):
     get_calls = []
     mocker.patch("requests.get", _mock_get(200, _tpz_type_data, get_calls))
     mocker.patch("builtins.open", mock_open(read_data=_tpz_type_data.decode("ascii")))
@@ -96,9 +120,11 @@ def test_get_categorical_field_values_download(mocker):
     mocker.patch("os.path.exists", Mock(return_value=False))
     mocker.patch("os.stat", Mock(return_value=_stat_result_tpzt))
 
+    pipeline = Pipeline(pipeline_dir, "tree-preservation-zone")
+
     api = API(MockSpecification(), "http://test", "/test/cache-dir")
 
-    values = api.get_valid_category_values("tree-preservation-zone")
+    values = api.get_valid_category_values("tree-preservation-zone", pipeline)
 
     assert len(get_calls) == 1
     assert get_calls[0] == "http://test/dataset/tree-preservation-zone-type.csv"
@@ -106,7 +132,7 @@ def test_get_categorical_field_values_download(mocker):
     assert values == {"tree-preservation-zone-type": ["area", "group", "woodland"]}
 
 
-def test_get_categorical_field_from_cache(mocker):
+def test_get_categorical_field_from_cache(mocker, pipeline_dir):
     get_mock = Mock()
 
     mocker.patch("requests.get", get_mock)
@@ -115,15 +141,17 @@ def test_get_categorical_field_from_cache(mocker):
     mocker.patch("os.path.exists", Mock(return_value=True))
     mocker.patch("os.stat", Mock(return_value=_stat_result_tpzt))
 
+    pipeline = Pipeline(pipeline_dir, "tree-preservation-zone")
+
     get_mock.assert_not_called()
 
     api = API(MockSpecification(), "http://test", "/test/cache-dir")
-    values = api.get_valid_category_values("tree-preservation-zone")
+    values = api.get_valid_category_values("tree-preservation-zone", pipeline)
 
     assert values == {"tree-preservation-zone-type": ["area", "group", "woodland"]}
 
 
-def test_get_categorical_field_from_cache_no_data(mocker):
+def test_get_categorical_field_from_cache_no_data(mocker, pipeline_dir):
     get_mock = Mock()
     open_mock = Mock()
 
@@ -133,30 +161,35 @@ def test_get_categorical_field_from_cache_no_data(mocker):
     mocker.patch("os.path.exists", Mock(return_value=True))
     mocker.patch("os.stat", Mock(return_value=_stat_result_empty))
 
+    pipeline = Pipeline(pipeline_dir, "tree-preservation-zone")
+
     get_mock.assert_not_called()
     open_mock.assert_not_called()
 
     api = API(MockSpecification(), "http://test", "/test/cache-dir")
-    values = api.get_valid_category_values("tree-preservation-zone")
+    values = api.get_valid_category_values("tree-preservation-zone", pipeline)
 
     # Empty files aren't put in the list
     assert values == {}
 
 
-def test_get_categorical_field_values_download_field_category(mocker):
+def test_get_categorical_field_values_download_field_category(mocker, pipeline_dir):
+    pipeline = Pipeline(pipeline_dir, "conservation-area-document")
+
     get_calls = []
     mocker.patch("requests.get", _mock_get(200, _tpz_type_data, get_calls))
     mocker.patch("builtins.open", mock_open(read_data=_cad_type_data.decode("ascii")))
     mocker.patch("os.makedirs", Mock())
     mocker.patch("os.path.exists", Mock(return_value=False))
-    mocker.patch("os.stat", Mock(return_value=_stat_result_cadt))
+    mocker.patch("os.stat", side_effect=[_stat_result_cadt, _stat_result_cadt])
 
     api = API(MockSpecification(), "http://test", "/test/cache-dir")
 
-    values = api.get_valid_category_values("conservation-area-document")
+    values = api.get_valid_category_values("conservation-area-document", pipeline)
 
     assert len(get_calls) == 1
     assert get_calls[0] == "http://test/dataset/conservation-area-document-type.csv"
     assert values == {
-        "document-type": ["area-appraisal", "notice", "designation-report", "area-map"]
+        "document-type": ["area-appraisal", "notice", "designation-report", "area-map"],
+        "DocumentType": ["area-appraisal", "notice", "designation-report", "area-map"],
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixes a bug where there were some fields in brownfield-land that are not getting invalid category issues generated. This was because the categorical datasets were being downloaded named after the replacement fields (planning-permission-type) so were not detected for some supplied fields (PermissionType). This PR adds the 'replaced' fields to the list of valid categories.

## Related Tickets & Documents

- Ticket Link https://github.com/orgs/digital-land/projects/9/views/14?pane=issue&itemId=102722953&issue=digital-land%7Cdigital-land-python%7C371
- Related Issue #
- Closes #371 


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

