### PR TITLE
adds hyphen replacement to invalid category check

### DIFF
--- a/digital_land/phase/harmonise.py
+++ b/digital_land/phase/harmonise.py
@@ -93,7 +93,7 @@ class HarmonisePhase(Phase):
                     value = row[field]
                     valid_category_values = [
                         category_value.replace("-", " ").lower()
-                        for category_value in self.valid_category_values
+                        for category_value in self.valid_category_values[field]
                     ]
                     if (
                         value

--- a/digital_land/phase/harmonise.py
+++ b/digital_land/phase/harmonise.py
@@ -91,7 +91,14 @@ class HarmonisePhase(Phase):
             for field in row:
                 if field in self.valid_category_values.keys():
                     value = row[field]
-                    if value and value.lower() not in self.valid_category_values[field]:
+                    valid_category_values = [
+                        category_value.replace("-", " ").lower()
+                        for category_value in self.valid_category_values
+                    ]
+                    if (
+                        value
+                        and value.replace("-", " ").lower() not in valid_category_values
+                    ):
                         self.issues.log_issue(field, "invalid category value", value)
 
                 o[field] = self.harmonise_field(field, row[field])

--- a/digital_land/phase/harmonise.py
+++ b/digital_land/phase/harmonise.py
@@ -91,16 +91,16 @@ class HarmonisePhase(Phase):
             for field in row:
                 if field in self.valid_category_values.keys():
                     value = row[field]
-                    valid_category_values = [
-                        category_value.replace("-", " ").lower()
-                        for category_value in self.valid_category_values[field]
-                    ]
                     if (
                         value
-                        and value.replace("-", " ").lower() not in valid_category_values
+                        and value.replace(" ", "-") in self.valid_category_values[field]
+                    ):
+                        # TODO: log a warning where we've replaced spaces to match categorical value
+                        row[field] = value.replace(" ", "-")
+                    elif (
+                        value and value.lower() not in self.valid_category_values[field]
                     ):
                         self.issues.log_issue(field, "invalid category value", value)
-
                 o[field] = self.harmonise_field(field, row[field])
 
             # remove future entry dates

--- a/tests/unit/phase/test_harmonise.py
+++ b/tests/unit/phase/test_harmonise.py
@@ -246,15 +246,20 @@ def test_validate_categorical_field_dataset():
                 "reference": "2",
                 "document-type": "other",
             },
+            {
+                "reference": "3",
+                "document-type": "area appraisal",
+            },
         ],
     )
 
     output = list(h.process(reader))
 
-    assert len(output) == 2
+    assert len(output) == 3
     # check the fields are set in the output
     assert output[0]["row"]["document-type"] == "notice"
     assert output[1]["row"]["document-type"] == "other"
+    assert output[2]["row"]["document-type"] == "area appraisal"
 
     assert len(issues.rows) == 1
     # but we get an issue generated

--- a/tests/unit/phase/test_harmonise.py
+++ b/tests/unit/phase/test_harmonise.py
@@ -250,16 +250,21 @@ def test_validate_categorical_field_dataset():
                 "reference": "3",
                 "document-type": "area appraisal",
             },
+            {
+                "reference": "4",
+                "document-type": "area-appraisal",
+            },
         ],
     )
 
     output = list(h.process(reader))
 
-    assert len(output) == 3
+    assert len(output) == 4
     # check the fields are set in the output
     assert output[0]["row"]["document-type"] == "notice"
     assert output[1]["row"]["document-type"] == "other"
-    assert output[2]["row"]["document-type"] == "area appraisal"
+    assert output[2]["row"]["document-type"] == "area-appraisal"
+    assert output[3]["row"]["document-type"] == "area-appraisal"
 
     assert len(issues.rows) == 1
     # but we get an issue generated


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

In the categorical field check, we have been checking for exact string matches between the values in the data and the values in our datasets. This has been problematic for brownfield-land, where the guidance suggests to use spaces and our datasets have hyphens. This changes handles this so that we replace spaces with hyphens only if this would create a match to a categorical value

## Related Tickets & Documents

- Ticket Link
- Related Issue #375 
- Closes #375 

