### PR TITLE
handles capitalisation when replacing spaces in categorical check

### DIFF
--- a/digital_land/phase/harmonise.py
+++ b/digital_land/phase/harmonise.py
@@ -93,10 +93,11 @@ class HarmonisePhase(Phase):
                     value = row[field]
                     if (
                         value
-                        and value.replace(" ", "-") in self.valid_category_values[field]
+                        and value.lower().replace(" ", "-")
+                        in self.valid_category_values[field]
                     ):
                         # TODO: log a warning where we've replaced spaces to match categorical value
-                        row[field] = value.replace(" ", "-")
+                        row[field] = value.lower().replace(" ", "-")
                     elif (
                         value and value.lower() not in self.valid_category_values[field]
                     ):

--- a/tests/unit/phase/test_harmonise.py
+++ b/tests/unit/phase/test_harmonise.py
@@ -254,17 +254,22 @@ def test_validate_categorical_field_dataset():
                 "reference": "4",
                 "document-type": "area-appraisal",
             },
+            {
+                "reference": "5",
+                "document-type": "Area Appraisal",
+            },
         ],
     )
 
     output = list(h.process(reader))
 
-    assert len(output) == 4
+    assert len(output) == 5
     # check the fields are set in the output
     assert output[0]["row"]["document-type"] == "notice"
     assert output[1]["row"]["document-type"] == "other"
     assert output[2]["row"]["document-type"] == "area-appraisal"
     assert output[3]["row"]["document-type"] == "area-appraisal"
+    assert output[4]["row"]["document-type"] == "area-appraisal"
 
     assert len(issues.rows) == 1
     # but we get an issue generated


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The categorical field check was not accounting for capitalisation when replacing spaces in values. This PR adjusts the replacement so it fixes capitalisation when replacing spaces with hypens if it would match to a categorical value. 

e.g:
Not Permissioned -> not-permissioned


