### PR TITLE
adds retire old endpoints functionality to add data

### DIFF
--- a/digital_land/collection.py
+++ b/digital_land/collection.py
@@ -412,6 +412,20 @@ class Collection:
     def resource_path(self, resource):
         return resource_path(resource, self.dir)
 
+    def filtered_sources(self, filter: dict):
+        return [
+            entry
+            for entry in self.source.entries
+            if all(
+                (
+                    v in entry.get(k, "").split(";")
+                    if k == "pipelines" and ";" in str(entry.get(k, ""))
+                    else entry.get(k) == v
+                )
+                for k, v in filter.items()
+            )
+        ]
+
     def pipeline_makerules(
         self,
         specification_dir,

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -1091,7 +1091,6 @@ def add_data(
                     if get_user_response(f"{source['endpoint-url']}? (yes/no): "):
                         sources_to_retire.append(source)
 
-                print(sources_to_retire)
                 if sources_to_retire:
                     collection.retire_endpoints_and_sources(
                         pd.DataFrame.from_records(sources_to_retire)

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -1078,17 +1078,17 @@ def add_data(
 
         # Now check for existing endpoints for this provision/organisation
         existing_endpoints_summary, existing_sources = get_existing_endpoints_summary(
-            endpoint_resource_info, collection, "test"
+            endpoint_resource_info, collection, dataset
         )
         if existing_endpoints_summary:
             print(existing_endpoints_summary)
             if get_user_response(
-                "Do you want to retire any of these existing endpoints?"
+                "Do you want to retire any of these existing endpoints? (yes/no): "
             ):
                 # iterate over existing sources and ask if they should be retired
                 sources_to_retire = []
                 for source in existing_sources:
-                    if get_user_response(f"{source['endpoint-url']}?"):
+                    if get_user_response(f"{source['endpoint-url']}? (yes/no): "):
                         sources_to_retire.append(source)
 
                 print(sources_to_retire)

--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -67,6 +67,7 @@ from digital_land.utils.add_data_utils import (
     clear_log,
     get_column_field_summary,
     get_entity_summary,
+    get_existing_endpoints_summary,
     get_issue_summary,
     is_date_valid,
     is_url_valid,
@@ -980,6 +981,7 @@ def add_data(
         )
         print(entity_summary)
 
+        entities_assigned = False
         # Check for unknown entities and assign them
         if (
             "unknown entity" in issue_summary
@@ -1060,23 +1062,40 @@ def add_data(
                     f"Unknown entities remain in resource {endpoint_resource_info['resource']} after assigning entities"
                 )
 
-            # Ask if user wants to proceed
-            if not get_user_response(
-                "Do you want to save changes made in this session? (yes/no): "
-            ):
-                return
+            entities_assigned = True
 
-            # Save changes to lookup.csv
-            shutil.copy(cache_pipeline_dir / "lookup.csv", pipeline_dir / "lookup.csv")
-        else:
-            # Ask if user wants to proceed
-            if not get_user_response(
-                "Do you want to save changes made in this session? (yes/no): "
-            ):
-                return
+        # Ask if user wants to proceed
+        if not get_user_response(
+            "Do you want to save changes made in this session? (yes/no): "
+        ):
+            return
 
         # Save changes to collection
         collection.save_csv()
+        if entities_assigned:
+            # Save changes to lookup.csv
+            shutil.copy(cache_pipeline_dir / "lookup.csv", pipeline_dir / "lookup.csv")
+
+        # Now check for existing endpoints for this provision/organisation
+        existing_endpoints_summary, existing_sources = get_existing_endpoints_summary(
+            endpoint_resource_info, collection, "test"
+        )
+        if existing_endpoints_summary:
+            print(existing_endpoints_summary)
+            if get_user_response(
+                "Do you want to retire any of these existing endpoints?"
+            ):
+                # iterate over existing sources and ask if they should be retired
+                sources_to_retire = []
+                for source in existing_sources:
+                    if get_user_response(f"{source['endpoint-url']}?"):
+                        sources_to_retire.append(source)
+
+                print(sources_to_retire)
+                if sources_to_retire:
+                    collection.retire_endpoints_and_sources(
+                        pd.DataFrame.from_records(sources_to_retire)
+                    )
 
 
 def add_endpoints_and_lookups(

--- a/digital_land/utils/add_data_utils.py
+++ b/digital_land/utils/add_data_utils.py
@@ -249,34 +249,30 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
         {"organisation": endpoint_resource_info["organisation"], "pipelines": dataset}
     )
     # filter out the endpoint in endpoint_resource_info as this has just been added
-    # also filter out endpoints that have ended
-    print(existing_sources)
+    # filter out endpoints and sources that have ended
     existing_sources = [
         source
         for source in existing_sources
         if (source["endpoint"] != endpoint_resource_info["endpoint"])
-        and (source["end-date"] == "")
+        and (
+            source["end-date"] == ""
+            or collection.endpoint.records[source["endpoint"]][0]["end-date"] == ""
+        )
     ]
 
     existing_endpoints_summary = ""
     if existing_sources:
-        # need to fetch endpoint urls separately as they aren't in source, so create a lookup
-        endpoint_lookup = {
-            entry["endpoint"]: entry["endpoint-url"]
-            for entry in collection.endpoint.entries
-        }
-
         existing_endpoints_summary += "Existing endpoints found for this provision:\n"
         existing_endpoints_summary += "\nentry-date, endpoint-url"
+
         for source in existing_sources:
+            source["endpoint-url"] = collection.endpoint.records[source["endpoint"]][0][
+                "endpoint-url"
+            ]
 
-            endpoint_hash = source["endpoint"]
-            if endpoint_hash in endpoint_lookup:
-                source["endpoint-url"] = endpoint_lookup[endpoint_hash]
-
-                existing_endpoints_summary += (
-                    f"\n{source['entry-date']}, {source['endpoint-url']}"
-                )
+            existing_endpoints_summary += (
+                f"\n{source['entry-date']}, {source['endpoint-url']}"
+            )
         return existing_endpoints_summary, existing_sources
     else:
         return "", []

--- a/digital_land/utils/add_data_utils.py
+++ b/digital_land/utils/add_data_utils.py
@@ -248,11 +248,14 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
     existing_sources = collection.filtered_sources(
         {"organisation": endpoint_resource_info["organisation"], "pipelines": dataset}
     )
-    # filter the source in endpoint_resource_info as this has just been added
+    # filter out the endpoint in endpoint_resource_info as this has just been added
+    # also filter out endpoints that have ended
+    print(existing_sources)
     existing_sources = [
         source
         for source in existing_sources
-        if source["source"] != endpoint_resource_info["source"]
+        if (source["endpoint"] != endpoint_resource_info["endpoint"])
+        and (source["end-date"] == "")
     ]
 
     existing_endpoints_summary = ""

--- a/digital_land/utils/add_data_utils.py
+++ b/digital_land/utils/add_data_utils.py
@@ -264,15 +264,12 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
     if existing_sources:
         existing_endpoints_summary += "Existing endpoints found for this provision:\n"
         existing_endpoints_summary += "\nentry-date, endpoint-url"
-
         for source in existing_sources:
             source["endpoint-url"] = collection.endpoint.records[source["endpoint"]][0][
                 "endpoint-url"
             ]
-
             existing_endpoints_summary += (
                 f"\n{source['entry-date']}, {source['endpoint-url']}"
             )
-        return existing_endpoints_summary, existing_sources
-    else:
-        return "", []
+
+    return existing_endpoints_summary, existing_sources

--- a/tests/acceptance/test_add_data.py
+++ b/tests/acceptance/test_add_data.py
@@ -548,7 +548,7 @@ def test_cli_add_data_old_endpoints_retired(
 
     # check that the endpoint and source have been retired
     endpoint_df = pd.read_csv(os.path.join(collection_dir, "endpoint.csv"))
-    endpoint_df["end-date"].values[0] == datetime.utcnow().isoformat()[:10]
+    assert endpoint_df["end-date"].values[0] == datetime.utcnow().isoformat()[:10]
 
     source_df = pd.read_csv(os.path.join(collection_dir, "source.csv"))
-    source_df["end-date"].values[0] == datetime.utcnow().isoformat()[:10]
+    assert source_df["end-date"].values[0] == datetime.utcnow().isoformat()[:10]

--- a/tests/integration/test_collection.py
+++ b/tests/integration/test_collection.py
@@ -549,3 +549,268 @@ def test_collection_retire_endpoints_and_sources(tmp_path):
 
     assert updated_endpoint_df.to_dict() == expected_endpoint_data
     assert updated_source_df.to_dict() == expected_source_data
+
+
+def test_filter_sources(tmp_path):
+    collection_dir = os.path.join(tmp_path, "collection")
+    os.makedirs(collection_dir, exist_ok=True)
+    endpoints = [
+        {
+            "endpoint": "test",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "endpoint": "test2",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "endpoint.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=endpoints[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(endpoints)
+
+    sources = [
+        {
+            "source": "test1",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org1",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "source": "test2",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org2",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=sources[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(sources)
+
+    collection = Collection(directory=collection_dir)
+    collection.load()
+
+    filtered_sources = collection.filtered_sources({"organisation": "test-org1"})
+
+    assert len(filtered_sources) == 1
+    assert all(source["organisation"] == "test-org1" for source in filtered_sources)
+
+
+def test_filter_sources_multiple_filters(tmp_path):
+    collection_dir = os.path.join(tmp_path, "collection")
+    os.makedirs(collection_dir, exist_ok=True)
+    endpoints = [
+        {
+            "endpoint": "test",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "endpoint": "test2",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "endpoint": "test3",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "endpoint.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=endpoints[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(endpoints)
+
+    sources = [
+        {
+            "source": "test1",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org1",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "source": "test2",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org2",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "source": "test3",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org3",
+            "pipelines": "test3",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=sources[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(sources)
+
+    collection = Collection(directory=collection_dir)
+    collection.load()
+
+    filtered_sources = collection.filtered_sources(
+        {"organisation": "test-org3", "pipelines": "test3"}
+    )
+
+    assert len(filtered_sources) == 1
+    assert all(
+        source["organisation"] == "test-org3" and source["pipelines"] == "test3"
+        for source in filtered_sources
+    )
+
+
+def test_filter_sources_pipeline_filter(tmp_path):
+    collection_dir = os.path.join(tmp_path, "collection")
+    os.makedirs(collection_dir, exist_ok=True)
+    endpoints = [
+        {
+            "endpoint": "test",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "endpoint": "test2",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "endpoint": "test3",
+            "endpoint-url": "test.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "endpoint.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=endpoints[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(endpoints)
+
+    sources = [
+        {
+            "source": "test1",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org1",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "source": "test2",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org2",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+        {
+            "source": "test3",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "endpoint": "test",
+            "licence": "test",
+            "organisation": "test-org3",
+            "pipelines": "test3;test4",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=sources[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(sources)
+
+    collection = Collection(directory=collection_dir)
+    collection.load()
+
+    filtered_sources = collection.filtered_sources({"pipelines": "test4"})
+
+    assert len(filtered_sources) == 1
+    assert all("test4" in source["pipelines"] for source in filtered_sources)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the ability to retire old endpoints after adding an endpoint with the add data command. The command will list endpoints for the current organisation/dataset and ask if the user wants to retire any of them, then ask for which specific endpoints should be retired

## Related Tickets & Documents

- Ticket Link
- Related Issue #388 
- Closes #388


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
