### PR TITLE
Add data - retire old endpoints considers sources with no endpoints

### DIFF
--- a/digital_land/commands.py
+++ b/digital_land/commands.py
@@ -1081,8 +1081,8 @@ def add_data(
         existing_endpoints_summary, existing_sources = get_existing_endpoints_summary(
             endpoint_resource_info, collection, dataset
         )
-        if existing_endpoints_summary:
-            print(existing_endpoints_summary)
+        print(existing_endpoints_summary)
+        if existing_sources:
             if get_user_response(
                 "Do you want to retire any of these existing endpoints? (yes/no): "
             ):

--- a/digital_land/utils/add_data_utils.py
+++ b/digital_land/utils/add_data_utils.py
@@ -168,7 +168,10 @@ def get_issue_summary(endpoint_resource_info, issue_dir):
     )
 
     issue_summary += "\n"
-    issue_summary += issue_df.groupby(["issue-type", "field"]).size().to_string()
+    if len(issue_df) > 0:
+        issue_summary += issue_df.groupby(["issue-type", "field"]).size().to_string()
+    else:
+        issue_summary += "No issues"
 
     return issue_summary
 
@@ -262,10 +265,16 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
 
     existing_endpoints_summary = ""
     if existing_sources:
-        existing_endpoints_summary += "Existing endpoints found for this provision:\n"
+        existing_endpoints_summary += "\nExisting endpoints found for this provision:\n"
         existing_endpoints_summary += "\nentry-date, endpoint-url"
         for source in existing_sources:
-            source["endpoint-url"] = collection.endpoint.records[source["endpoint"]][0][
+            endpoint_hash = source.get("endpoint", "")
+            if not endpoint_hash:
+                existing_endpoints_summary += (
+                    f"\nWARNING: No endpoint found for source {source['source']}"
+                )
+                continue
+            source["endpoint-url"] = collection.endpoint.records[endpoint_hash][0][
                 "endpoint-url"
             ]
             existing_endpoints_summary += (

--- a/digital_land/utils/add_data_utils.py
+++ b/digital_land/utils/add_data_utils.py
@@ -267,12 +267,12 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
     if existing_sources:
         existing_endpoints_summary += "\nExisting endpoints found for this provision:\n"
         existing_endpoints_summary += "\nentry-date, endpoint-url"
+        retirable_sources = []
         for source in existing_sources:
             endpoint_hash = source.get("endpoint", "")
+            # Some legacy sources don't have endpoints
             if not endpoint_hash:
-                existing_endpoints_summary += (
-                    f"\nWARNING: No endpoint found for source {source['source']}"
-                )
+                existing_endpoints_summary += f"\nWARNING: No endpoint found for source {source['source']}. Add end date manually if necessary."
                 continue
             source["endpoint-url"] = collection.endpoint.records[endpoint_hash][0][
                 "endpoint-url"
@@ -280,5 +280,6 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
             existing_endpoints_summary += (
                 f"\n{source['entry-date']}, {source['endpoint-url']}"
             )
+            retirable_sources.append(source)
 
-    return existing_endpoints_summary, existing_sources
+    return existing_endpoints_summary, retirable_sources

--- a/digital_land/utils/add_data_utils.py
+++ b/digital_land/utils/add_data_utils.py
@@ -264,10 +264,10 @@ def get_existing_endpoints_summary(endpoint_resource_info, collection, dataset):
     ]
 
     existing_endpoints_summary = ""
+    retirable_sources = []
     if existing_sources:
         existing_endpoints_summary += "\nExisting endpoints found for this provision:\n"
         existing_endpoints_summary += "\nentry-date, endpoint-url"
-        retirable_sources = []
         for source in existing_sources:
             endpoint_hash = source.get("endpoint", "")
             # Some legacy sources don't have endpoints

--- a/tests/integration/test_add_data_utils.py
+++ b/tests/integration/test_add_data_utils.py
@@ -922,3 +922,4 @@ def test_get_existing_endpoints_source_with_no_endpoint(tmp_path):
     )
 
     assert "WARNING: No endpoint found for source test1" in existing_endpoints_summary
+    assert len(existing_sources) == 0

--- a/tests/integration/test_add_data_utils.py
+++ b/tests/integration/test_add_data_utils.py
@@ -52,6 +52,23 @@ def test_get_issue_summary(tmp_path_factory):
     assert "issue-type2  field1    2" in issue_summary
 
 
+def test_get_issue_summary_no_issues(tmp_path_factory):
+    issue_dir = tmp_path_factory.mktemp("issue")
+
+    resource = "resource"
+    endpoint_resource_info = {"resource": resource}
+
+    headers = ["issue-type", "field", "value"]
+
+    with open(os.path.join(issue_dir, resource + ".csv"), "w") as f:
+        writer = csv.DictWriter(f, fieldnames=headers)
+        writer.writeheader()
+
+    issue_summary = get_issue_summary(endpoint_resource_info, issue_dir)
+
+    assert "No issues" in issue_summary
+
+
 def test_get_entity_summary(tmp_path_factory):
     issue_dir = tmp_path_factory.mktemp("issue")
     transformed_dir = tmp_path_factory.mktemp("tranformed")
@@ -847,3 +864,61 @@ def test_get_existing_endpoints_summary_ended_endpoint_and_source(tmp_path):
     assert not existing_endpoints_summary
 
     assert not existing_sources
+
+
+def test_get_existing_endpoints_source_with_no_endpoint(tmp_path):
+    collection_dir = os.path.join(tmp_path, "collection")
+    os.makedirs(collection_dir, exist_ok=True)
+    endpoints = [
+        {
+            "endpoint": "differentendpoint",
+            "endpoint-url": "test1.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "endpoint.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=endpoints[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(endpoints)
+
+    sources = [
+        {
+            "source": "test1",
+            "endpoint": "",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "licence": "test",
+            "organisation": "test-org1",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=sources[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(sources)
+
+    endpoint_resource_info = {
+        "source": "test3",
+        "endpoint": "test3",
+        "organisation": "test-org1",
+        "pipelines": "test",
+    }
+
+    collection = Collection(directory=collection_dir)
+    collection.load()
+
+    existing_endpoints_summary, existing_sources = get_existing_endpoints_summary(
+        endpoint_resource_info, collection, "test"
+    )
+
+    assert "WARNING: No endpoint found for source test1" in existing_endpoints_summary

--- a/tests/integration/test_add_data_utils.py
+++ b/tests/integration/test_add_data_utils.py
@@ -923,3 +923,62 @@ def test_get_existing_endpoints_source_with_no_endpoint(tmp_path):
 
     assert "WARNING: No endpoint found for source test1" in existing_endpoints_summary
     assert len(existing_sources) == 0
+
+
+def test_get_existing_endpoints_ended_source_with_no_endpoint(tmp_path):
+    collection_dir = os.path.join(tmp_path, "collection")
+    os.makedirs(collection_dir, exist_ok=True)
+    endpoints = [
+        {
+            "endpoint": "differentendpoint",
+            "endpoint-url": "test1.com",
+            "parameters": "",
+            "plugin": "",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "endpoint.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=endpoints[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(endpoints)
+
+    sources = [
+        {
+            "source": "test1",
+            "endpoint": "",
+            "attribution": "",
+            "collection": "test",
+            "documentation-url": "testing.com",
+            "licence": "test",
+            "organisation": "test-org1",
+            "pipelines": "test",
+            "entry-date": "2019-01-01",
+            "start-date": "2019-01-01",
+            "end-date": "end-date",
+        },
+    ]
+
+    with open(os.path.join(collection_dir, "source.csv"), "w") as f:
+        dictwriter = csv.DictWriter(f, fieldnames=sources[0].keys())
+        dictwriter.writeheader()
+        dictwriter.writerows(sources)
+
+    endpoint_resource_info = {
+        "source": "test3",
+        "endpoint": "test3",
+        "organisation": "test-org1",
+        "pipelines": "test",
+    }
+
+    collection = Collection(directory=collection_dir)
+    collection.load()
+
+    existing_endpoints_summary, existing_sources = get_existing_endpoints_summary(
+        endpoint_resource_info, collection, "test"
+    )
+
+    assert not existing_endpoints_summary
+    assert len(existing_sources) == 0


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The add data command was crashing when trying to retire old legacy sources that didn't have endpoints. This PR fixes the crashing and asks the user to end sources with no endpoint manually

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests
