### PR TITLE
adds ability to download .sqlite3 dataset to API class

### DIFF
--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -110,10 +110,7 @@ def test_get_categorical_field_read_csv(pipeline_dir, tmp_path_factory):
 def test_download_dataset_sqlite(mocker, tmp_path):
 
     # Create a temporary sqlite3 db
-    with tempfile.NamedTemporaryFile(
-        delete=False,
-        suffix=".sqlite3",
-    ) as tmp:
+    with tempfile.NamedTemporaryFile(suffix=".sqlite3") as tmp:
         tmp_path_sqlite = tmp.name
 
     conn = sqlite3.connect(tmp_path_sqlite)
@@ -130,7 +127,6 @@ def test_download_dataset_sqlite(mocker, tmp_path):
     mock_response = mocker.Mock()
     mock_response.status_code = 200
     mock_response.content = sqlite_data
-    mock_response.raise_for_status = lambda: None
     mocker.patch("requests.get", return_value=mock_response)
 
     api = API(MockSpecification(), "http://test", "/test/cache-dir")

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,5 +1,7 @@
 import csv
 import os
+import sqlite3
+import tempfile
 
 import pytest
 
@@ -37,6 +39,7 @@ class MockSpecification:
                 "document-type": "conservation-area-document-type"
             },
         }
+        self.dataset = {"test_dataset": {"collection": "test_collection"}}
 
     def get_category_fields(self, dataset):
         return self.category_fields[dataset]
@@ -102,3 +105,44 @@ def test_get_categorical_field_read_csv(pipeline_dir, tmp_path_factory):
 
     # check that the replacement-field has also been given valid values
     assert values["DocumentType"] == ["NEW TYPE"]
+
+
+def test_download_dataset_sqlite(mocker, tmp_path):
+
+    # Create a temporary sqlite3 db
+    with tempfile.NamedTemporaryFile(
+        delete=False,
+        suffix=".sqlite3",
+    ) as tmp:
+        tmp_path_sqlite = tmp.name
+
+    conn = sqlite3.connect(tmp_path_sqlite)
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT);")
+    cursor.execute("INSERT INTO test (name) VALUES ('example');")
+    conn.commit()
+    conn.close()
+
+    with open(tmp.name, "rb") as f:
+        sqlite_data = f.read()
+
+    # mocker.patch("requests.get", _mock_get(200, sqlite_data))
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.content = sqlite_data
+    mock_response.raise_for_status = lambda: None
+    mocker.patch("requests.get", return_value=mock_response)
+
+    api = API(MockSpecification(), "http://test", "/test/cache-dir")
+    path = tmp_path / "test.sqlite3"
+
+    api.download_dataset("test_dataset", path=path, extension=api.Extension.SQLITE3)
+
+    # Now check if downloaded sqlite db is accessible
+    conn = sqlite3.connect(path)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM test WHERE id = 1;")
+    row = cursor.fetchone()
+    conn.close()
+
+    assert row[0] == "example"

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -89,7 +89,7 @@ def test_download_dataset_specified(mocker):
 
     api = API(Mock(), "http://test", "/test/cache-dir")
 
-    api.download_dataset("test", csv_path="test.csv")
+    api.download_dataset("test", path="test.csv")
 
 
 def test_download_dataset_overwrite(mocker):
@@ -99,7 +99,7 @@ def test_download_dataset_overwrite(mocker):
 
     api = API(Mock(), "http://test", "/test/cache-dir")
 
-    api.download_dataset("test", overwrite=True, csv_path="test.csv")
+    api.download_dataset("test", overwrite=True, path="test.csv")
 
 
 def test_download_dataset_error(mocker):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds the functionality to the API class to download a dataset as a .sqlite3 database

## Related Tickets & Documents

- Ticket Link
- Related Issue #397 
- Closes #397 

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

