### PR TITLE
feat: add name_is_a_code expectation

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -17,6 +17,7 @@ from ..operations.dataset import (
     count_deleted_entities,
     duplicate_geometry_check,
     fetch_active_resources_for_dataset,
+    name_is_a_code_check,
 )
 
 
@@ -42,6 +43,7 @@ class DatasetCheckpoint(BaseCheckpoint):
             "count_lpa_boundary": count_lpa_boundary,
             "count_deleted_entities": count_deleted_entities,
             "duplicate_geometry_check": duplicate_geometry_check,
+            "name_is_a_code_check": name_is_a_code_check,
         }
         operation = operation_map[operation_string]
         return operation

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import sqlite3
 import requests
 import pandas as pd
@@ -461,6 +462,70 @@ def duplicate_geometry_check(conn, spatial_field: str):
         "single_matches": single_matches,
         "any_matches": any_matches,
     }
+    return result, message, details
+
+
+# Flags a name which contains at least one digit, is 20 characters or fewer, and is
+# made up only of letters, digits, dots, slashes and hyphens - a bare reference code
+# rather than a description. The digit lookahead is what stops plain single-word place
+# names such as 'Napsbury' being flagged.
+CODE_LIKE_NAME_RE = re.compile(r"^(?=.*[0-9])[A-Za-z0-9./-]{1,20}$")
+
+
+def name_is_a_code_check(conn):
+    """
+    Checks for entities whose name is just a bare reference code rather than a
+    description, e.g. '59', '0164B2' or '11/802'.
+
+    Failures carry organisation_entity rather than an organisation curie. The dataset
+    package deliberately keeps 'organisation' out of the entity json (package/dataset.py),
+    so organisation_entity is the only provenance available here - resolving it to a
+    curie is the bridge's job.
+
+    Blank names are not flagged here - they are already covered by the existing
+    missing values issue, and the pattern cannot match an empty string anyway.
+
+    args:
+        conn: connection to the dataset being checked, created by the checkpoint class
+    """
+    # length is a cheap superset of the pattern's {1,20}, so this can only ever exclude
+    # rows the pattern would have rejected, and it keeps the regex off most of the table
+    query = """
+        select entity, reference, name, organisation_entity
+        from entity
+        where name is not null
+            and trim(name) != ''
+            and length(name) <= 20
+    """
+    rows = conn.execute(query).fetchall()
+
+    failures = [
+        {
+            "organisation_entity": organisation_entity,
+            "entity": entity,
+            "reference": reference,
+            "name": name,
+        }
+        for entity, reference, name, organisation_entity in rows
+        if CODE_LIKE_NAME_RE.match(name)
+    ]
+
+    failures.sort(
+        key=lambda failure: (
+            failure["organisation_entity"] or "",
+            failure["reference"] or "",
+        )
+    )
+
+    result = len(failures) == 0
+    message = f"{len(failures)} entities have a name which is only a reference code"
+    details = {
+        "failures": failures,
+        "field": "name",
+        "actual": len(failures),
+        "expected": 0,
+    }
+
     return result, message, details
 
 

--- a/tests/acceptance/test_run_expectations_on_sqlite.py
+++ b/tests/acceptance/test_run_expectations_on_sqlite.py
@@ -137,6 +137,71 @@ def config_path(tmp_path, specification_dir):
     return config_path
 
 
+@pytest.fixture
+def name_check_dataset_path(tmp_path):
+    """a dataset with one bare code name and one descriptive name"""
+    dataset_path = tmp_path / "name_check.sqlite3"
+    create_entity_table_sql = """
+        CREATE TABLE entity (
+            dataset TEXT,
+            end_date TEXT,
+            entity INTEGER PRIMARY KEY,
+            entry_date TEXT,
+            geojson JSON,
+            geometry TEXT,
+            json JSON,
+            name TEXT,
+            organisation_entity TEXT,
+            point TEXT,
+            prefix TEXT,
+            reference TEXT,
+            start_date TEXT,
+            typology TEXT
+        );
+    """
+    with spatialite.connect(dataset_path) as con:
+        con.execute(create_entity_table_sql)
+        con.executemany(
+            "INSERT INTO entity (entity, reference, name, organisation_entity)"
+            " VALUES (?, ?, ?, ?)",
+            [
+                (1, "CA-59", "59", "122"),
+                (2, "CA-WYM", "Wymondham Conservation Area", "122"),
+            ],
+        )
+
+    return dataset_path
+
+
+@pytest.fixture
+def name_check_config_path(tmp_path, specification_dir):
+    """a configuration enabling name_is_a_code_check, with no organisations and empty
+    parameters, matching how the rule will be written in config"""
+    config_path = tmp_path / "name_check_config.sqlite3"
+    rules = [
+        {
+            "datasets": "test",
+            "organisations": "",
+            "name": "Check no entities have a name which is only a code",
+            "operation": "name_is_a_code_check",
+            "parameters": "{}",
+            "responsibility": "external",
+            "severity": "warning",
+        }
+    ]
+    expect_path = tmp_path / "expect.csv"
+    with open(expect_path, mode="w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=rules[0].keys())
+        writer.writeheader()
+        writer.writerows(rules)
+
+    spec = Specification(specification_dir)
+    config = Config(path=config_path, specification=spec)
+    config.create()
+    config.load({"expect": str(tmp_path)})
+    return config_path
+
+
 def test_run_some_expectations(
     tmp_path, organisation_path, dataset_path, config_path, specification_dir, mocker
 ):
@@ -228,3 +293,58 @@ def test_run_some_expectations(
     assert (
         len([result for result in results if result["passed"] == "True"]) == 1
     ), "expected 1 passed expectation"
+
+
+def test_run_name_is_a_code_expectation(
+    tmp_path,
+    organisation_path,
+    name_check_dataset_path,
+    name_check_config_path,
+    specification_dir,
+):
+    dataset = "test"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        expectations_run_dataset_checkpoint,
+        [
+            "--dataset",
+            dataset,
+            "--file-path",
+            str(name_check_dataset_path),
+            "--log-dir",
+            str(tmp_path / "log"),
+            "--configuration-path",
+            str(name_check_config_path),
+            "--organisation-path",
+            str(organisation_path),
+            "--specification-dir",
+            str(specification_dir),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+
+    log_path = tmp_path / f"log/expectation/dataset={dataset}/{dataset}.parquet"
+    assert log_path.exists(), "no logs created"
+
+    conn = duckdb.connect()
+    cursor = conn.execute(f"SELECT * FROM read_parquet('{str(log_path)}')")
+    columns = [desc[0] for desc in cursor.description]
+    results = [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    assert len(results) == 1, "expected one expectation to have run"
+    log = results[0]
+    assert log["operation"] == "name_is_a_code_check"
+    assert log["passed"] == "False", "the bare code name should have failed the check"
+    assert log["severity"] == "warning"
+    assert log["responsibility"] == "external"
+    assert (
+        log["organisation"] == ""
+    ), "a rule with no organisations logs a blank organisation"
+
+    details = json.loads(log["details"])
+    assert details["actual"] == 1
+    assert [failure["name"] for failure in details["failures"]] == ["59"]
+    assert details["failures"][0]["organisation_entity"] == "122"

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -11,6 +11,7 @@ from digital_land.expectations.operations.dataset import (
     count_deleted_entities,
     duplicate_geometry_check,
     fetch_active_resources_for_dataset,
+    name_is_a_code_check,
 )
 
 
@@ -722,3 +723,72 @@ def test_check_fields_required_after_plan_event_null_value(
             "actual-date": "2024-12-12",
         }
     ]
+
+
+def test_name_is_a_code_check(dataset_path):
+    entities = [
+        # bare codes, should be flagged
+        (1, "A4D-59", "59", "600001", "local-authority:EXE"),
+        (2, "CA-3B", "3B", "600002", "local-authority:ARU"),
+        (3, "LBO-802", "11/802", "600002", "local-authority:ARU"),
+        # descriptive names, should not be flagged
+        (4, "CA-WYM", "Wymondham Conservation Area", "600001", "local-authority:EXE"),
+        (5, "LBO-GOODGE", "56, GOODGE STREET", "600002", "local-authority:ARU"),
+        # no digit, should not be flagged - this is what the lookahead is for
+        (6, "CA-NAP", "Napsbury", "600001", "local-authority:EXE"),
+        # over 20 characters, should not be flagged
+        (7, "CA-LONG", "123456789012345678901", "600001", "local-authority:EXE"),
+        # blank, belongs to the missing values issue not this check
+        (8, "CA-BLANK", "", "600001", "local-authority:EXE"),
+    ]
+    with spatialite.connect(dataset_path) as con:
+        for entity, reference, name, organisation_entity, _organisation in entities:
+            con.execute(
+                "INSERT INTO entity (entity, reference, name, organisation_entity)"
+                " VALUES (?, ?, ?, ?)",
+                (entity, reference, name, organisation_entity),
+            )
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = name_is_a_code_check(conn=con)
+
+    assert not passed, message
+    assert details["actual"] == 3
+    assert details["expected"] == 0
+    assert details["field"] == "name"
+    assert details["failures"] == [
+        {
+            "organisation_entity": "600001",
+            "entity": 1,
+            "reference": "A4D-59",
+            "name": "59",
+        },
+        {
+            "organisation_entity": "600002",
+            "entity": 2,
+            "reference": "CA-3B",
+            "name": "3B",
+        },
+        {
+            "organisation_entity": "600002",
+            "entity": 3,
+            "reference": "LBO-802",
+            "name": "11/802",
+        },
+    ]
+
+
+def test_name_is_a_code_check_all_descriptive(dataset_path):
+    with spatialite.connect(dataset_path) as con:
+        con.execute(
+            "INSERT INTO entity (entity, reference, name, organisation_entity)"
+            " VALUES (?, ?, ?, ?)",
+            (1, "CA-WYM", "Wymondham Conservation Area", "600001"),
+        )
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = name_is_a_code_check(conn=con)
+
+    assert passed, message
+    assert details["failures"] == []
+    assert details["actual"] == 0


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds a new dataset expectation, `name_is_a_code_check`, which flags entities whose `name` is only a bare reference code rather than a description — for example `59`, `3B` or `11/802` — and registers it in the dataset checkpoint's operation map. Failures are reported per entity with their `organisation_entity`, so they can be attributed back to the provider.

The check is inert until it is switched on for a dataset by an `expect.csv` row in `config`, so this PR changes no behaviour on its own. It is intended for `article-4-direction-area`, `conservation-area` and `listed-building-outline` only.

## Why

Part of the work to give LPAs feedback on `name` field quality. Analysis of the ODP spatial datasets found a significant number of entities whose name carries no information for a data user, because the provider has supplied their internal reference instead of a descriptive name.

Note that nothing is yet visible to an LPA: expectations do not currently generate tasks. That bridge is config#2912 and is deliberately out of scope here.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2909)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

The check was also run against the current published data for all three datasets in scope, and the counts reconcile exactly with the 2026-08 ODP name analysis:

| dataset | flagged | analysis figure |
|---|---|---|
| article-4-direction-area | 104 of 7,327 (1.4%) | 104 (1.4%) |
| conservation-area | 10 of 11,019 (0.1%) | 10 (0.1%) |
| listed-building-outline | 144 of 126,271 (0.1%) | 144 (0.1%) |

That is 258 entities across roughly 20 organisations in total.

## Context - low risk change:

The operation does nothing until an `expect.csv` row in config names it, so merging this changes no behaviour anywhere. When it is switched on it runs at `warning` severity, which cannot fail a dataset build, and it only reads the `entity` table — it writes nothing back to the dataset. Nothing is visible to a data provider yet either, because expectations do not currently generate tasks.

## Future testing before this goes live.

Once this is merged I will set up the PR to change in config and then test that in DEV before merging to main.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
