### PR TITLE
feat: name_is_a_placeholder expectation

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -18,6 +18,7 @@ from ..operations.dataset import (
     duplicate_geometry_check,
     fetch_active_resources_for_dataset,
     name_is_a_code_check,
+    name_is_a_placeholder_check,
 )
 
 
@@ -44,6 +45,7 @@ class DatasetCheckpoint(BaseCheckpoint):
             "count_deleted_entities": count_deleted_entities,
             "duplicate_geometry_check": duplicate_geometry_check,
             "name_is_a_code_check": name_is_a_code_check,
+            "name_is_a_placeholder_check": name_is_a_placeholder_check,
         }
         operation = operation_map[operation_string]
         return operation

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -529,6 +529,118 @@ def name_is_a_code_check(conn):
     return result, message, details
 
 
+# Placeholder strings that some source systems write into `name` when they have no
+# real name, e.g. "No name for this Entry". Overridable per-dataset from the
+# parameters cell in config's expect.csv, so new boilerplate spotted in the data can
+# be added without a code release.
+DEFAULT_PLACEHOLDER_NAMES = [
+    "No name for this Entry",
+]
+
+
+def _normalise_name(name):
+    """casefold and collapse whitespace so matching ignores case and spacing"""
+    return re.sub(r"\s+", " ", name).strip().casefold()
+
+
+def name_is_a_placeholder_check(conn, listed_building_path, placeholders=None):
+    """
+    Checks for entities whose name is a placeholder string, e.g. 'No name for this
+    Entry', where the linked listed-building record holds a real name instead.
+
+    Matching is exact after normalisation - deliberately NOT a substring match, so a
+    real name which happens to contain the word 'name' is not flagged.
+
+    `name` is a mandatory field for listed-building-outline (MANDATORY_FIELDS_DICT in
+    digital_land/phase/harmonise.py), so a blank name already raises a missing value
+    issue.
+
+    args:
+        conn: connection to the dataset being checked, created by the checkpoint class
+        listed_building_path: path to a local copy of the built listed-building sqlite,
+            fetched as a published artifact during assemble
+        placeholders: list of placeholder strings; falls back to
+            DEFAULT_PLACEHOLDER_NAMES when absent or empty, so a parameters cell
+            carrying only the path still works
+    """
+    if not placeholders:
+        placeholders = DEFAULT_PLACEHOLDER_NAMES
+    # a single string in config would otherwise iterate as characters and match any
+    # one-character name, so treat it as one placeholder
+    if isinstance(placeholders, str):
+        placeholders = [placeholders]
+
+    placeholder_set = {_normalise_name(placeholder) for placeholder in placeholders}
+
+    # a missing artifact must never fail the build, the check just can't run
+    if not listed_building_path or not os.path.isfile(listed_building_path):
+        message = (
+            f"listed-building not available at '{listed_building_path}', check skipped"
+        )
+        logging.warning(message)
+        return True, message, {"skipped": True, "failures": []}
+
+    # listed-building is not a core entity column, so it lives in the json blob.
+    query = """
+        select
+            e.entity,
+            e.reference,
+            e.name,
+            e.organisation_entity,
+            lb.name as listed_building_name
+        from entity e
+        inner join listed_building.entity lb
+            on lb.reference = json_extract(e.json, '$."listed-building"')
+        where e.name is not null
+            and trim(e.name) != ''
+            and lb.name is not null
+            and trim(lb.name) != ''
+    """
+
+    conn.execute("ATTACH DATABASE ? AS listed_building", (str(listed_building_path),))
+    try:
+        rows = conn.execute(query).fetchall()
+    finally:
+        conn.execute("DETACH DATABASE listed_building")
+
+    failures = [
+        {
+            "organisation_entity": organisation_entity,
+            "entity": entity,
+            "reference": reference,
+            "name": name,
+            "listed_building_name": listed_building_name,
+        }
+        for entity, reference, name, organisation_entity, listed_building_name in rows
+        # the listed-building name must be a real name too - swapping one placeholder
+        # for another is not a fix worth asking an organisation to make
+        if _normalise_name(name) in placeholder_set
+        and _normalise_name(listed_building_name) not in placeholder_set
+    ]
+
+    failures.sort(
+        key=lambda failure: (
+            failure["organisation_entity"] or "",
+            failure["reference"] or "",
+            failure["entity"],
+        )
+    )
+
+    result = len(failures) == 0
+    message = (
+        f"{len(failures)} entities have a placeholder name where the listed building "
+        "record holds a real name"
+    )
+    details = {
+        "failures": failures,
+        "field": "name",
+        "actual": len(failures),
+        "expected": 0,
+    }
+
+    return result, message, details
+
+
 def check_fields_required_after_plan_event(
     conn,
     fields: list,

--- a/tests/acceptance/test_run_expectations_on_sqlite.py
+++ b/tests/acceptance/test_run_expectations_on_sqlite.py
@@ -202,6 +202,113 @@ def name_check_config_path(tmp_path, specification_dir):
     return config_path
 
 
+@pytest.fixture
+def placeholder_check_dataset_path(tmp_path):
+    """a dataset with one placeholder name and one real name, both linked to a
+    listed-building record"""
+    dataset_path = tmp_path / "placeholder_check.sqlite3"
+    create_entity_table_sql = """
+        CREATE TABLE entity (
+            dataset TEXT,
+            end_date TEXT,
+            entity INTEGER PRIMARY KEY,
+            entry_date TEXT,
+            geojson JSON,
+            geometry TEXT,
+            json JSON,
+            name TEXT,
+            organisation_entity TEXT,
+            point TEXT,
+            prefix TEXT,
+            reference TEXT,
+            start_date TEXT,
+            typology TEXT
+        );
+    """
+    with spatialite.connect(dataset_path) as con:
+        con.execute(create_entity_table_sql)
+        con.executemany(
+            "INSERT INTO entity (entity, reference, name, organisation_entity, json)"
+            " VALUES (?, ?, ?, ?, ?)",
+            [
+                (
+                    1,
+                    "LBO-A",
+                    "No name for this Entry",
+                    "122",
+                    json.dumps({"listed-building": "1234567"}),
+                ),
+                (
+                    2,
+                    "LBO-C",
+                    "NORTH LODGE",
+                    "122",
+                    json.dumps({"listed-building": "2222222"}),
+                ),
+            ],
+        )
+
+    return dataset_path
+
+
+@pytest.fixture
+def listed_building_artifact_path(tmp_path):
+    """stands in for the listed-building sqlite fetched from S3 during assemble"""
+    artifact_path = tmp_path / "listed-building.sqlite3"
+    with spatialite.connect(artifact_path) as con:
+        con.execute(
+            """
+            CREATE TABLE entity (
+                entity INTEGER PRIMARY KEY,
+                name TEXT,
+                reference TEXT
+            );
+        """
+        )
+        con.executemany(
+            "INSERT INTO entity (entity, name, reference) VALUES (?, ?, ?)",
+            [
+                (900001, "33, 37 AND 39, BAYFORD GREEN", "1234567"),
+                (900002, "NORTH LODGE", "2222222"),
+            ],
+        )
+
+    return artifact_path
+
+
+@pytest.fixture
+def placeholder_check_config_path(
+    tmp_path, specification_dir, listed_building_artifact_path
+):
+    """a configuration enabling name_is_a_placeholder_check, carrying the artifact path
+    in parameters exactly as the rule will be written in config"""
+    config_path = tmp_path / "placeholder_check_config.sqlite3"
+    rules = [
+        {
+            "datasets": "test",
+            "organisations": "",
+            "name": "Check no entities have a placeholder name",
+            "operation": "name_is_a_placeholder_check",
+            "parameters": json.dumps(
+                {"listed_building_path": str(listed_building_artifact_path)}
+            ),
+            "responsibility": "external",
+            "severity": "error",
+        }
+    ]
+    expect_path = tmp_path / "expect.csv"
+    with open(expect_path, mode="w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=rules[0].keys())
+        writer.writeheader()
+        writer.writerows(rules)
+
+    spec = Specification(specification_dir)
+    config = Config(path=config_path, specification=spec)
+    config.create()
+    config.load({"expect": str(tmp_path)})
+    return config_path
+
+
 def test_run_some_expectations(
     tmp_path, organisation_path, dataset_path, config_path, specification_dir, mocker
 ):
@@ -348,3 +455,62 @@ def test_run_name_is_a_code_expectation(
     assert details["actual"] == 1
     assert [failure["name"] for failure in details["failures"]] == ["59"]
     assert details["failures"][0]["organisation_entity"] == "122"
+
+
+def test_run_name_is_a_placeholder_expectation(
+    tmp_path,
+    organisation_path,
+    placeholder_check_dataset_path,
+    placeholder_check_config_path,
+    specification_dir,
+):
+    dataset = "test"
+    runner = CliRunner()
+
+    result = runner.invoke(
+        expectations_run_dataset_checkpoint,
+        [
+            "--dataset",
+            dataset,
+            "--file-path",
+            str(placeholder_check_dataset_path),
+            "--log-dir",
+            str(tmp_path / "log"),
+            "--configuration-path",
+            str(placeholder_check_config_path),
+            "--organisation-path",
+            str(organisation_path),
+            "--specification-dir",
+            str(specification_dir),
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+
+    log_path = tmp_path / f"log/expectation/dataset={dataset}/{dataset}.parquet"
+    assert log_path.exists(), "no logs created"
+
+    conn = duckdb.connect()
+    cursor = conn.execute(f"SELECT * FROM read_parquet('{str(log_path)}')")
+    columns = [desc[0] for desc in cursor.description]
+    results = [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+    assert len(results) == 1, "expected one expectation to have run"
+    log = results[0]
+    assert log["operation"] == "name_is_a_placeholder_check"
+    assert log["passed"] == "False", "the placeholder name should have failed the check"
+    assert log["severity"] == "error"
+    assert log["responsibility"] == "external"
+    assert (
+        log["organisation"] == ""
+    ), "a rule with no organisations logs a blank organisation"
+
+    details = json.loads(log["details"])
+    assert details["actual"] == 1
+    assert [failure["name"] for failure in details["failures"]] == [
+        "No name for this Entry"
+    ]
+    assert (
+        details["failures"][0]["listed_building_name"] == "33, 37 AND 39, BAYFORD GREEN"
+    ), "the real name must reach details so the bridge can quote it back to the LPA"

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -12,6 +12,7 @@ from digital_land.expectations.operations.dataset import (
     duplicate_geometry_check,
     fetch_active_resources_for_dataset,
     name_is_a_code_check,
+    name_is_a_placeholder_check,
 )
 
 
@@ -792,3 +793,178 @@ def test_name_is_a_code_check_all_descriptive(dataset_path):
     assert passed, message
     assert details["failures"] == []
     assert details["actual"] == 0
+
+
+@pytest.fixture
+def listed_building_path(tmp_path):
+    """a minimal built listed-building sqlite, standing in for the Historic England
+    dataset fetched during assemble"""
+    listed_building_path = tmp_path / "listed-building.sqlite3"
+    with spatialite.connect(listed_building_path) as con:
+        con.execute(
+            """
+            CREATE TABLE entity (
+                entity INTEGER PRIMARY KEY,
+                name TEXT,
+                reference TEXT
+            );
+        """
+        )
+        con.executemany(
+            "INSERT INTO entity (entity, name, reference) VALUES (?, ?, ?)",
+            [
+                (900001, "33, 37 AND 39, BAYFORD GREEN", "1234567"),
+                (900002, "NORTH LODGE", "2222222"),
+                # the listed-building name is itself boilerplate, so there is nothing
+                # better to offer and the outline row must not be flagged
+                (900003, "No name for this Entry", "3333333"),
+                # a blank name is no use either
+                (900004, "", "4444444"),
+            ],
+        )
+    return listed_building_path
+
+
+def _insert_outline(con, entity, reference, name, organisation_entity, listed_building):
+    """listed-building is not a core entity column, so it goes in the json blob"""
+    con.execute(
+        "INSERT INTO entity (entity, reference, name, organisation_entity, json)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (
+            entity,
+            reference,
+            name,
+            organisation_entity,
+            json.dumps({"listed-building": listed_building} if listed_building else {}),
+        ),
+    )
+
+
+def test_name_is_a_placeholder_check(dataset_path, listed_building_path):
+    entities = [
+        # placeholder with a real listed-building name, should be flagged
+        (1, "LBO-A", "No name for this Entry", "600001", "1234567"),
+        # same placeholder in a different case and spacing, should still be flagged
+        (2, "LBO-B", "  no   NAME for this ENTRY  ", "600002", "2222222"),
+        # a real name appending locating detail, legitimate and not flagged
+        (
+            3,
+            "LBO-C",
+            "NORTH LODGE - B1318 (EAST SIDE) GOSFORTH PARK",
+            "600001",
+            "2222222",
+        ),
+        # listed-building name is itself a placeholder, nothing better to suggest
+        (4, "LBO-D", "No name for this Entry", "600001", "3333333"),
+        # listed-building name is blank
+        (5, "LBO-E", "No name for this Entry", "600001", "4444444"),
+        # listed-building reference matches no record
+        (6, "LBO-F", "No name for this Entry", "600001", "9999999"),
+        # no listed-building reference at all
+        (7, "LBO-G", "No name for this Entry", "600001", None),
+        # blank, belongs to the missing values issue not this check
+        (8, "LBO-H", "", "600001", "1234567"),
+        # contains placeholder-ish words but is a real name, must not substring match
+        (9, "LBO-I", "A building with no name plate", "600001", "1234567"),
+    ]
+    with spatialite.connect(dataset_path) as con:
+        for row in entities:
+            _insert_outline(con, *row)
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = name_is_a_placeholder_check(
+            conn=con, listed_building_path=listed_building_path
+        )
+
+    assert not passed, message
+    assert details["actual"] == 2
+    assert details["expected"] == 0
+    assert details["field"] == "name"
+    assert details["failures"] == [
+        {
+            "organisation_entity": "600001",
+            "entity": 1,
+            "reference": "LBO-A",
+            "name": "No name for this Entry",
+            "listed_building_name": "33, 37 AND 39, BAYFORD GREEN",
+        },
+        {
+            "organisation_entity": "600002",
+            "entity": 2,
+            "reference": "LBO-B",
+            "name": "  no   NAME for this ENTRY  ",
+            "listed_building_name": "NORTH LODGE",
+        },
+    ]
+
+
+def test_name_is_a_placeholder_check_all_real_names(dataset_path, listed_building_path):
+    with spatialite.connect(dataset_path) as con:
+        _insert_outline(con, 1, "LBO-C", "NORTH LODGE", "600001", "2222222")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = name_is_a_placeholder_check(
+            conn=con, listed_building_path=listed_building_path
+        )
+
+    assert passed, message
+    assert details["failures"] == []
+    assert details["actual"] == 0
+
+
+def test_name_is_a_placeholder_check_missing_artifact(dataset_path, tmp_path):
+    """a missing artifact must skip the check, never fail the build"""
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = name_is_a_placeholder_check(
+            conn=con,
+            listed_building_path=tmp_path / "does-not-exist.sqlite3",
+        )
+
+    assert passed
+    assert details["skipped"] is True
+    assert "check skipped" in message
+
+
+def test_name_is_a_placeholder_check_placeholders_from_config(
+    dataset_path, listed_building_path
+):
+    """the list is overridable from the parameters cell, so new boilerplate spotted in
+    the data can be added without a code release"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_outline(con, 1, "LBO-J", "No given name", "600001", "1234567")
+
+    with spatialite.connect(dataset_path) as con:
+        # not in the default list, so nothing is flagged
+        passed, _message, _details = name_is_a_placeholder_check(
+            conn=con, listed_building_path=listed_building_path
+        )
+        assert passed
+
+        passed, _message, details = name_is_a_placeholder_check(
+            conn=con,
+            listed_building_path=listed_building_path,
+            placeholders=["No given name"],
+        )
+
+    assert not passed
+    assert [failure["name"] for failure in details["failures"]] == ["No given name"]
+
+
+def test_name_is_a_placeholder_check_single_string_placeholder(
+    dataset_path, listed_building_path
+):
+    """a bare string in config must be treated as one placeholder rather than iterated
+    as characters, which would match any single character name"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_outline(con, 1, "LBO-J", "No given name", "600001", "1234567")
+        _insert_outline(con, 2, "LBO-K", "N", "600001", "2222222")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, _message, details = name_is_a_placeholder_check(
+            conn=con,
+            listed_building_path=listed_building_path,
+            placeholders="No given name",
+        )
+
+    assert not passed
+    assert [failure["reference"] for failure in details["failures"]] == ["LBO-J"]


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `name_is_a_placeholder_check`, a dataset expectation flagging `listed-building-outline` entities whose `name` is boilerplate — `"No name for this Entry"` — where the linked Historic England `listed-building` record holds a real name. The real name travels in `details.failures` so the bridge can quote it back to the publisher. The placeholder list is configurable from the `parameters` cell in config.

This is the `digital-land-python` half of digital-land/config#2910, following the same shape as `name_is_a_code_check` from #582.

## Why

`name` is mandatory for `listed-building-outline`, so a blank raises a `missing value` error — but boilerplate is a non-empty string and slips through, ending up published as the building's name. Same defect, so the same `error` severity. The 2026-08 ODP name analysis found 845 such rows across two organisations, 844 of which link to a record holding the correct name.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2910)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## QA

Checked against real published data and at production scale, beyond the test suite.

**Join key format** — sampled the published `listed-building-outline.csv` and `listed-building.csv`. The `listed-building` values (`1024710`) and listed-building `reference` values (`1021466`) are bare numeric strings on both sides, with no curie prefix, so the join key is correct. This was the main silent-failure risk: a format mismatch would have returned zero failures forever without erroring.

**Real-data support for the join** — in a 4,817-row sample, `"No given name"` is the single most common name (219 occurrences). That is the placeholder with a 2-in-220 link rate, so a string-only check would flood those organisations with unactionable rows while this one raises almost nothing. Around 37% of outline rows carry no `listed-building` reference at all and are therefore never flagged.

## Why this is safe to merge on its own

This PR is inert until the `config` row lands. The operation is reachable only through the `operation_map` lookup in `operation_factory`, which is keyed by the `operation` value of an `expect.csv` rule. No config rule names `name_is_a_placeholder_check`, so nothing calls it. The additions are a list constant and two function definitions with no import-time side effects, nothing enumerates `operation_map`, and no existing operation changes.

Next I will create an a siser PR in config, and will test this all run fin in DEV before merging that into main and therefor making this live.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added validation to identify entity names that appear to be reference codes.
  * Added validation to detect placeholder names by comparing them with linked listed-building names.
  * Supports configurable placeholder names and safely handles unavailable external records.
  * Validation results include detailed entity and organisation information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->