### PR TITLE
fix: update PrintLookupPhase to allow processing without organisation

### DIFF
--- a/digital_land/phase/lookup.py
+++ b/digital_land/phase/lookup.py
@@ -478,7 +478,7 @@ class PrintLookupPhase(LookupPhase):
                     row[self.entity_field] = self.get_entity(block)
 
             if not row[self.entity_field]:
-                if prefix and organisation and reference:
+                if prefix and reference:
                     new_lookup = {
                         "prefix": prefix,
                         "organisation": organisation,

--- a/tests/unit/phase/test_lookup.py
+++ b/tests/unit/phase/test_lookup.py
@@ -243,6 +243,26 @@ class TestLookupPhase:
 
 
 class TestPrintLookupPhase:
+    def test_process_produces_lookup_without_organisation(self):
+        input_stream = [
+            {
+                "row": {
+                    "prefix": "dataset",
+                    "reference": "1",
+                    "organisation": "",
+                },
+                "entry-number": 1,
+                "line-number": 2,
+            }
+        ]
+        phase = PrintLookupPhase()
+
+        list(phase.process(input_stream))
+
+        assert phase.new_lookup_entries == [
+            [{"prefix": "dataset", "organisation": "", "reference": "1"}]
+        ]
+
     def test_process_does_not_produce_new_lookup(self, get_input_stream, get_lookup):
         input_stream = get_input_stream
         lookups = get_lookup


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Allow `PrintLookupPhase` to create a lookup entry when an organisation is not provided, as long as a prefix and reference are present.

## Related Tickets & Documents

- Ticket Link: N/A
- Related Issue #: N/A
- Closes #: N/A

## QA Instructions, Screenshots, Recordings

Run:

```sh
.venv/bin/pytest tests/unit/phase/test_lookup.py
.venv/bin/black --check digital_land/phase/lookup.py tests/unit/phase/test_lookup.py
.venv/bin/flake8 digital_land/phase/lookup.py tests/unit/phase/test_lookup.py
```

All checks pass. No UI changes.

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why:
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

None.

## [optional] Are there any dependencies on other PRs or Work?

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lookup entries are now created when a prefix and reference are provided, even if the organisation field is blank.
  * Blank organisation details are retained in the resulting lookup entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->