### PR TITLE
feat: add duplicate_name_check expectation

### DIFF
--- a/digital_land/expectations/checkpoints/dataset.py
+++ b/digital_land/expectations/checkpoints/dataset.py
@@ -16,6 +16,7 @@ from ..operations.dataset import (
     count_lpa_boundary,
     count_deleted_entities,
     duplicate_geometry_check,
+    duplicate_name_check,
     fetch_active_resources_for_dataset,
     name_is_a_code_check,
     name_is_a_placeholder_check,
@@ -44,6 +45,7 @@ class DatasetCheckpoint(BaseCheckpoint):
             "count_lpa_boundary": count_lpa_boundary,
             "count_deleted_entities": count_deleted_entities,
             "duplicate_geometry_check": duplicate_geometry_check,
+            "duplicate_name_check": duplicate_name_check,
             "name_is_a_code_check": name_is_a_code_check,
             "name_is_a_placeholder_check": name_is_a_placeholder_check,
         }

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -641,6 +641,83 @@ def name_is_a_placeholder_check(conn, listed_building_path, placeholders=None):
     return result, message, details
 
 
+def duplicate_name_check(conn, threshold=2):
+    """
+    Checks for names reused across several entities within the same provision, i.e.
+    the same dataset and organisation. Usually means one feature was split into
+    several polygons and the parts were never distinguished.
+
+    Grouping is per organisation, not dataset-wide. The published dataset is every
+    LPA's file concatenated together, so a dataset-wide comparison flags authorities
+    for other authorities' word choices - 'City Centre' appears once each in seven
+    different councils, and none of them can act on that.
+
+    Failures are one entry per duplicated name rather than per entity, matching the
+    analysis this came from. Member entity ids are nested under 'entities' so a
+    drill-down page can page through them without re-running the check.
+
+    Matching is case- and whitespace-insensitive via _normalise_name, but not
+    otherwise fuzzy: two directions differing only by year are different names.
+
+    Blank names are not compared - they are already covered by the missing values
+    issue, and every blank would otherwise be a duplicate of every other blank.
+
+    args:
+        conn: connection to the dataset being checked, created by the checkpoint class
+        threshold: how many entities must share a name before it is reported.
+            Exposed so it can be raised from config without a code release.
+    """
+    query = """
+        select entity, reference, name, organisation_entity
+        from entity
+        where name is not null
+            and trim(name) != ''
+    """
+    rows = conn.execute(query).fetchall()
+
+    groups = {}
+    for entity, reference, name, organisation_entity in rows:
+        key = (organisation_entity, _normalise_name(name))
+        # keep the first raw spelling seen: the normalised key is not worth showing to
+        # an LPA, and two rows differing only in case would otherwise look identical
+        group = groups.setdefault(key, {"name": name, "entities": [], "references": []})
+        group["entities"].append(entity)
+        group["references"].append(reference)
+
+    failures = [
+        {
+            "organisation_entity": organisation_entity,
+            "name": group["name"],
+            "count": len(group["entities"]),
+            "entities": sorted(group["entities"]),
+            "references": sorted(
+                reference for reference in group["references"] if reference
+            ),
+        }
+        for (organisation_entity, _), group in groups.items()
+        if len(group["entities"]) >= threshold
+    ]
+
+    failures.sort(
+        key=lambda failure: (
+            failure["organisation_entity"] or "",
+            -failure["count"],
+            failure["name"],
+        )
+    )
+
+    result = len(failures) == 0
+    message = f"{len(failures)} names are used by {threshold} or more entities"
+    details = {
+        "failures": failures,
+        "field": "name",
+        "actual": len(failures),
+        "expected": 0,
+    }
+
+    return result, message, details
+
+
 def check_fields_required_after_plan_event(
     conn,
     fields: list,

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -668,7 +668,7 @@ def duplicate_name_check(conn, threshold=2):
             Exposed so it can be raised from config without a code release.
     """
     query = """
-        select entity, reference, name, organisation_entity
+        select entity, reference, name, organisation_entity, dataset
         from entity
         where name is not null
             and trim(name) != ''
@@ -677,13 +677,13 @@ def duplicate_name_check(conn, threshold=2):
     rows = conn.execute(query).fetchall()
 
     groups = {}
-    for entity, reference, name, organisation_entity in rows:
+    for entity, reference, name, organisation_entity, dataset in rows:
         normalised = _normalise_name(name)
         # sqlite's trim() only strips spaces, so a tab- or newline-only name survives
         # the query. left in, every such row would group together under an empty key.
         if not normalised:
             continue
-        key = (organisation_entity, normalised)
+        key = (dataset, organisation_entity, normalised)
         # keep the raw spelling of the lowest entity id: the normalised key is not worth
         # showing to an LPA, and two rows differing only in case would otherwise look
         # identical. the order by makes which spelling wins stable across rebuilds.
@@ -701,7 +701,7 @@ def duplicate_name_check(conn, threshold=2):
                 reference for reference in group["references"] if reference
             ),
         }
-        for (organisation_entity, _), group in groups.items()
+        for (_, organisation_entity, _), group in groups.items()
         if len(group["entities"]) >= threshold
     ]
 

--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -672,14 +672,21 @@ def duplicate_name_check(conn, threshold=2):
         from entity
         where name is not null
             and trim(name) != ''
+        order by entity
     """
     rows = conn.execute(query).fetchall()
 
     groups = {}
     for entity, reference, name, organisation_entity in rows:
-        key = (organisation_entity, _normalise_name(name))
-        # keep the first raw spelling seen: the normalised key is not worth showing to
-        # an LPA, and two rows differing only in case would otherwise look identical
+        normalised = _normalise_name(name)
+        # sqlite's trim() only strips spaces, so a tab- or newline-only name survives
+        # the query. left in, every such row would group together under an empty key.
+        if not normalised:
+            continue
+        key = (organisation_entity, normalised)
+        # keep the raw spelling of the lowest entity id: the normalised key is not worth
+        # showing to an LPA, and two rows differing only in case would otherwise look
+        # identical. the order by makes which spelling wins stable across rebuilds.
         group = groups.setdefault(key, {"name": name, "entities": [], "references": []})
         group["entities"].append(entity)
         group["references"].append(reference)

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -1053,11 +1053,15 @@ def test_duplicate_name_check_ignores_case_and_spacing(dataset_path):
 
 
 def test_duplicate_name_check_ignores_blank_names(dataset_path):
-    """blanks belong to the missing values issue, and would all match each other"""
+    """blanks belong to the missing values issue, and would all match each other.
+    sqlite's trim() only strips spaces, so tabs and newlines must be caught in python"""
     with spatialite.connect(dataset_path) as con:
         _insert_named(con, 1, "CA-1", "", "600001")
         _insert_named(con, 2, "CA-2", "   ", "600001")
         _insert_named(con, 3, "CA-3", None, "600001")
+        _insert_named(con, 4, "CA-4", "\t", "600001")
+        _insert_named(con, 5, "CA-5", "\n", "600001")
+        _insert_named(con, 6, "CA-6", "  \t  ", "600001")
 
     with spatialite.connect(dataset_path) as con:
         passed, message, details = duplicate_name_check(conn=con)

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -10,6 +10,7 @@ from digital_land.expectations.operations.dataset import (
     count_lpa_boundary,
     count_deleted_entities,
     duplicate_geometry_check,
+    duplicate_name_check,
     fetch_active_resources_for_dataset,
     name_is_a_code_check,
     name_is_a_placeholder_check,
@@ -968,3 +969,114 @@ def test_name_is_a_placeholder_check_single_string_placeholder(
 
     assert not passed
     assert [failure["reference"] for failure in details["failures"]] == ["LBO-J"]
+
+
+def _insert_named(con, entity, reference, name, organisation_entity):
+    con.execute(
+        "INSERT INTO entity (entity, reference, name, organisation_entity)"
+        " VALUES (?, ?, ?, ?)",
+        (entity, reference, name, organisation_entity),
+    )
+
+
+def test_duplicate_name_check(dataset_path):
+    entities = [
+        # same name twice in one org, should be flagged
+        (1, "A4D-1", "Site allocation NSP30", "600001"),
+        (2, "A4D-2", "Site allocation NSP30", "600001"),
+        # three in one org, should be flagged with a count of 3
+        (3, "A4D-3", "District Centre related A4D", "600001"),
+        (4, "A4D-4", "District Centre related A4D", "600001"),
+        (5, "A4D-5", "District Centre related A4D", "600001"),
+        # used once, should not be flagged
+        (6, "A4D-6", "Queen's Park", "600001"),
+    ]
+    with spatialite.connect(dataset_path) as con:
+        for entity, reference, name, organisation_entity in entities:
+            _insert_named(con, entity, reference, name, organisation_entity)
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con)
+
+    assert not passed, message
+    assert details["actual"] == 2
+    assert details["expected"] == 0
+    assert details["field"] == "name"
+    # sorted by organisation then count descending, so the group of 3 comes first
+    assert details["failures"] == [
+        {
+            "organisation_entity": "600001",
+            "name": "District Centre related A4D",
+            "count": 3,
+            "entities": [3, 4, 5],
+            "references": ["A4D-3", "A4D-4", "A4D-5"],
+        },
+        {
+            "organisation_entity": "600001",
+            "name": "Site allocation NSP30",
+            "count": 2,
+            "entities": [1, 2],
+            "references": ["A4D-1", "A4D-2"],
+        },
+    ]
+
+
+def test_duplicate_name_check_is_scoped_per_organisation(dataset_path):
+    """the same name in two authorities is coincidence, not a defect neither can fix"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_named(con, 1, "CA-1", "City Centre", "600001")
+        _insert_named(con, 2, "CA-2", "City Centre", "600002")
+        _insert_named(con, 3, "CA-3", "City Centre", "600003")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con)
+
+    assert passed, message
+    assert details["failures"] == []
+
+
+def test_duplicate_name_check_ignores_case_and_spacing(dataset_path):
+    """grouping uses _normalise_name, but the raw spelling is what gets reported"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_named(con, 1, "A4D-1", "POTENTIAL LEISURE PLOTS", "600001")
+        _insert_named(con, 2, "A4D-2", "Potential  Leisure Plots", "600001")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con)
+
+    assert not passed, message
+    assert details["actual"] == 1
+    failure = details["failures"][0]
+    assert failure["count"] == 2
+    # the normalised key would be unrecognisable to the authority that wrote it
+    assert failure["name"] == "POTENTIAL LEISURE PLOTS"
+
+
+def test_duplicate_name_check_ignores_blank_names(dataset_path):
+    """blanks belong to the missing values issue, and would all match each other"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_named(con, 1, "CA-1", "", "600001")
+        _insert_named(con, 2, "CA-2", "   ", "600001")
+        _insert_named(con, 3, "CA-3", None, "600001")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con)
+
+    assert passed, message
+    assert details["failures"] == []
+
+
+def test_duplicate_name_check_threshold_from_config(dataset_path):
+    with spatialite.connect(dataset_path) as con:
+        _insert_named(con, 1, "A4D-1", "Pair", "600001")
+        _insert_named(con, 2, "A4D-2", "Pair", "600001")
+        _insert_named(con, 3, "A4D-3", "Trio", "600001")
+        _insert_named(con, 4, "A4D-4", "Trio", "600001")
+        _insert_named(con, 5, "A4D-5", "Trio", "600001")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con, threshold=3)
+
+    assert not passed, message
+    assert [failure["name"] for failure in details["failures"]] == ["Trio"]
+    assert "3 or more entities" in message

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -971,11 +971,11 @@ def test_name_is_a_placeholder_check_single_string_placeholder(
     assert [failure["reference"] for failure in details["failures"]] == ["LBO-J"]
 
 
-def _insert_named(con, entity, reference, name, organisation_entity):
+def _insert_named(con, entity, reference, name, organisation_entity, dataset=None):
     con.execute(
-        "INSERT INTO entity (entity, reference, name, organisation_entity)"
-        " VALUES (?, ?, ?, ?)",
-        (entity, reference, name, organisation_entity),
+        "INSERT INTO entity (entity, reference, name, organisation_entity, dataset)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (entity, reference, name, organisation_entity, dataset),
     )
 
 
@@ -1033,6 +1033,45 @@ def test_duplicate_name_check_is_scoped_per_organisation(dataset_path):
 
     assert passed, message
     assert details["failures"] == []
+
+
+def test_duplicate_name_check_is_scoped_per_dataset(dataset_path):
+    """one connection may hold more than one dataset. the same name in two of them is
+    not a duplicate - grouping is per provision, which is dataset and organisation"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_named(
+            con, 1, "A4D-1", "Town Centre", "600001", "article-4-direction-area"
+        )
+        _insert_named(con, 2, "CA-1", "Town Centre", "600001", "conservation-area")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con)
+
+    assert passed, message
+    assert details["failures"] == []
+
+
+def test_duplicate_name_check_still_flags_within_one_dataset(dataset_path):
+    """the dataset partition must not suppress a genuine duplicate sitting alongside
+    the same name in another dataset"""
+    with spatialite.connect(dataset_path) as con:
+        _insert_named(
+            con, 1, "A4D-1", "Town Centre", "600001", "article-4-direction-area"
+        )
+        _insert_named(
+            con, 2, "A4D-2", "Town Centre", "600001", "article-4-direction-area"
+        )
+        _insert_named(con, 3, "CA-1", "Town Centre", "600001", "conservation-area")
+
+    with spatialite.connect(dataset_path) as con:
+        passed, message, details = duplicate_name_check(conn=con)
+
+    assert not passed, message
+    assert details["actual"] == 1
+    failure = details["failures"][0]
+    assert failure["count"] == 2
+    assert failure["entities"] == [1, 2]
+    assert failure["references"] == ["A4D-1", "A4D-2"]
 
 
 def test_duplicate_name_check_ignores_case_and_spacing(dataset_path):


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## What

Adds a `duplicate_name_check` dataset expectation, which flags names reused by several entities within the same provision — the same dataset and organisation.

## Why

Part 3 of digital-land#598. The same `name` text is reused across distinct entities, so the name stops identifying anything — usually one feature split into several polygons whose parts were never distinguished. For example one authority used `"Conservation_Area.TAB"` for 27 conservation areas, and another used `"District Centre related A4D"` for 364 article-4-direction areas.

Grouping is per organisation rather than dataset-wide because the published dataset is every LPA's file concatenated together; `"City Centre"` appears once each in seven different councils, and none of them can act on that. Matching reuses the existing `_normalise_name` helper, so case and spacing variants group together while the raw spelling is what gets reported.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2911)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

## Testing

5 integration tests covering per-organisation scoping, the threshold parameter, normalisation, blank exclusion and the failure structure. 105 expectations tests pass, black and flake8 clean.

Checked against currently published data: 466 duplicate-name groups for `article-4-direction-area` and 178 for `conservation-area`.


## This change is inert
This change is inert on its own. The operation only runs for a dataset once a row naming it is added to that collection's `expect.csv`, so merging this alters no pipeline output. Opting in `article-4-direction-area` and `conservation-area` follows in a separate config PR.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dataset validation to detect repeated entity names.
  - Matching is case- and whitespace-insensitive, while blank names are excluded.
  - Supports configurable thresholds for identifying duplicates.
  - Results are consistently ordered and include relevant entity references.

- **Tests**
  - Added coverage for duplicate detection, dataset and organisation scoping, name normalisation, blank-name handling, and configurable thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->