### PR TITLE
fix: allow lookup entries without an organisation to validate

### DIFF
--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -943,7 +943,7 @@ class Lookups:
     # @staticmethod
     def validate_entry(self, entry) -> bool:
         # ensures minimum expected fields exist and are not empty strings
-        expected_fields = ["prefix", "organisation", "reference"]
+        expected_fields = ["prefix", "reference"]
         for field in expected_fields:
             if not entry.get(field, ""):
                 raise ValueError(f"ERROR: expected {field} not found in lookup entry")

--- a/digital_land/pipeline/main.py
+++ b/digital_land/pipeline/main.py
@@ -955,7 +955,7 @@ class Lookups:
                     1
                     for item in self.entries
                     if item["prefix"] == entry["prefix"]
-                    and item["organisation"] == entry["organisation"]
+                    and item.get("organisation", "") == entry.get("organisation", "")
                     and item["reference"] == entry["reference"]
                 ]
             )

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -206,6 +206,26 @@ class TestPipeLine:
         actual_result = lookups.validate_entry(entry)
         assert actual_result == expected_result
 
+    def test_lookups_validate_entry_success_without_organisation(self):
+        """
+        PrintLookupPhase emits entries for rows with no organisation, so an
+        otherwise complete entry must validate with a blank organisation
+        :return:
+        """
+        lookups = Lookups("")
+
+        entry = {
+            "prefix": "ancient-woodland",
+            "resource": "",
+            "organisation": "",
+            "reference": "1",
+            "entity": "",
+        }
+
+        expected_result = True
+        actual_result = lookups.validate_entry(entry)
+        assert actual_result == expected_result
+
     @pytest.mark.parametrize(
         "entry",
         [


### PR DESCRIPTION
PR #584 relaxed `PrintLookupPhase` so a lookup entry is emitted for rows with no organisation:

```diff
-                if prefix and organisation and reference:
+                if prefix and reference:
```

but `Lookups.validate_entry` still requires one:

```python
expected_fields = ["prefix", "organisation", "reference"]
```

so digital-land now produces lookup entries that digital-land itself rejects with:

```
ValueError: ERROR: expected organisation not found in lookup entry
```

## Impact

Any consumer that feeds `PrintLookupPhase` output into `Lookups.add_entry` hits this. In `async-request-backend/request-processor` it surfaces as two failing integration tests, where the whole workflow returns a 500 instead of a result:

```
FAILED tests/integration/src/application/core/test_workflow.py::test_run_workflow
FAILED tests/integration/src/application/core/test_workflow.py::test_run_workflow_brownfield_land
AssertionError: assert 'converted-csv' in {'exception': 'ValueError', 'status': 500, ...}
```

Verified against request-processor with only the digital-land commit varying:

| digital-land | result |
| --- | --- |
| `fac1d93` (current main) | 2 failed, 2 passed |
| `fac1d93` + this change | **4 passed** |

## Why CI did not catch it

The two halves are each covered, but nothing joins them up:

- the test added in #584 asserts only what `PrintLookupPhase` *emits*, and never passes that entry to `validate_entry`
- every case in `test_lookups_validate_entry_failure` has an empty `prefix`, so they all raise on `prefix` and never reach the `organisation` check

This PR adds a regression test for the missing combination — a complete entry with a blank `organisation`.

## For reviewer attention

Removing the guard means blank-organisation entries now reach the duplicate check below it:

```python
if item["prefix"] == entry["prefix"]
and item["organisation"] == entry["organisation"]
and item["reference"] == entry["reference"]
```

Two entries sharing `prefix` + `reference` with blank organisations will now dedup as the same entry, where previously neither reached this code. If blank-organisation lookups can represent genuinely different organisations, that would collapse them into one entity — worth a check from whoever owns #584's intent.

## Testing

- `tests/unit/test_pipeline.py` and `tests/unit/phase/test_lookup.py` lookup tests: 9 passed (8 existing + 1 new)
- no change to the rest of the suite: 59 passed both before and after
- `black` and `flake8` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lookup entries can now be accepted without an organisation, provided the prefix and reference fields are completed.
  * Duplicate detection continues to distinguish entries using the organisation, prefix and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->