### PR TITLE
feat: standardise expectation returned details dict

### DIFF
--- a/digital_land/expectations/operations/dataset.py
+++ b/digital_land/expectations/operations/dataset.py
@@ -7,6 +7,7 @@ import pandas as pd
 import urllib
 import os
 import time
+from collections import defaultdict
 from datetime import datetime
 
 
@@ -46,7 +47,7 @@ def count_lpa_boundary(
     except requests.exceptions.RequestException as err:
         passed = False
         message = f"An error occurred when retrieving lpa geometry from platform {err}"
-        details = {}
+        details = {"error": str(err)}
         return passed, message, details
 
     # now deal with spatial options
@@ -87,7 +88,7 @@ def count_lpa_boundary(
 
     # set up initial query
     query = """
-        SELECT entity
+        SELECT entity, organisation_entity
         FROM entity
         WHERE (geometry != '' OR point != '')
     """
@@ -99,6 +100,9 @@ def count_lpa_boundary(
     rows = conn.execute(query).fetchall()
     entities = [row[0] for row in rows]
     actual = len(entities)
+    # one failure per offending entity, carrying the organisation from the data rather
+    # than the optional organisation_entity parameter, which not every config row supplies
+    failures = [{"organisation_entity": row[1], "entity": row[0]} for row in rows]
 
     # compare expected to actual
     # Define comparison rules
@@ -122,6 +126,7 @@ def count_lpa_boundary(
     message = f"there were {actual} entities found"
 
     details = {
+        "failures": failures,
         "actual": actual,
         "expected": expected,
         "entities": entities,
@@ -226,10 +231,16 @@ def count_deleted_entities(
     # identify entities present in the entity table but missing from the resource
     entities = [item for item in get_entities if item not in get_active_entities]
     actual = len(entities)
+    failures = (
+        [{"organisation_entity": str(organisation_entity), "count": actual}]
+        if actual
+        else []
+    )
 
     result = bool(actual == expected)
     message = f"there were {actual} entities found"
     details = {
+        "failures": failures,
         "actual": actual,
         "expected": expected,
         "entities": entities,
@@ -455,7 +466,45 @@ def duplicate_geometry_check(conn, spatial_field: str):
         complete_matches = []
         single_matches = []
         any_matches = []
+
+    match_counts = defaultdict(
+        lambda: {"complete_matches": 0, "single_matches": 0, "any_matches": 0}
+    )
+    for match_type, matches in (
+        ("complete_matches", complete_matches),
+        ("single_matches", single_matches),
+        ("any_matches", any_matches),
+    ):
+        for match in matches:
+            for org in {
+                match["organisation_entity_a"],
+                match["organisation_entity_b"],
+            }:
+                if org in (None, ""):
+                    continue
+                match_counts[org][match_type] += 1
+
+    # any_matches are polygons that merely intersect, neither covering 95% of the other -
+    # adjacency, not duplication. an organisation with only those has nothing to act on.
+    failures = [
+        {
+            "organisation_entity": str(org),
+            "complete_matches": counts["complete_matches"],
+            "single_matches": counts["single_matches"],
+            "any_matches": counts["any_matches"],
+            "count": counts["complete_matches"] + counts["single_matches"],
+        }
+        for org, counts in match_counts.items()
+        if counts["complete_matches"] + counts["single_matches"] > 0
+    ]
+    failures.sort(
+        key=lambda failure: (-failure["count"], failure["organisation_entity"])
+    )
+
+    # a dataset with only any_matches comes back passed=False with failures=[]: it has
+    # overlaps, but none of them actionable.
     details = {
+        "failures": failures,
         "actual": len(rows),
         "expected": 0,
         "complete_matches": complete_matches,
@@ -812,6 +861,8 @@ def check_fields_required_after_plan_event(
     )
     details = {
         "failures": failures,
+        "actual": len(failures),
+        "expected": 0,
         "fields": fields,
         "plan_event": plan_event,
         "plans_past_event": len(rows),

--- a/tests/integration/expectations/operations/test_dataset.py
+++ b/tests/integration/expectations/operations/test_dataset.py
@@ -3,6 +3,7 @@ import spatialite
 import sqlite3
 import pytest
 import pandas as pd
+import requests
 
 from digital_land.expectations.operations.dataset import (
     check_columns,
@@ -1123,3 +1124,163 @@ def test_duplicate_name_check_threshold_from_config(dataset_path):
     assert not passed, message
     assert [failure["name"] for failure in details["failures"]] == ["Trio"]
     assert "3 or more entities" in message
+
+
+def test_count_lpa_boundary_failures_carry_organisation_from_the_data(
+    dataset_path, mocker
+):
+    """the organisation must come from the entity row, not the optional
+    organisation_entity parameter, which not every config row supplies"""
+    geometry = "MULTIPOLYGON(((-0.4914554581046105 53.80708847427775,-0.5012039467692374 53.773842823566696,-0.4584064520895481 53.783669118729875,-0.4914554581046105 53.80708847427775)))"  # noqa E501
+    lpa_geometry = "MULTIPOLYGON(((-0.49901924973862233 53.81622315189787,-0.5177418530633007 53.76114469621959,-0.4268378912177833 53.78454002743749,-0.49901924973862233 53.81622315189787)))"  # noqa E501
+    test_entity_data = pd.DataFrame.from_dict(
+        {
+            "entity": [1, 2],
+            "name": ["test1", "test2"],
+            "organisation_entity": [122, 456],
+            "geometry": [geometry, geometry],
+            "point": ["POINT(-0.4850078825017034 53.786407721600625)"] * 2,
+        }
+    )
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"geometry": lpa_geometry}
+    mocker.patch("requests.get", return_value=mock_response)
+
+    with spatialite.connect(dataset_path) as conn:
+        test_entity_data.to_sql("entity", conn, if_exists="append", index=False)
+        # deliberately no organisation_entity parameter
+        passed, message, details = count_lpa_boundary(
+            conn, lpa="test", expected=2, geometric_relation="within"
+        )
+
+    assert passed, message
+    assert details["failures"] == [
+        {"organisation_entity": "122", "entity": 1},
+        {"organisation_entity": "456", "entity": 2},
+    ]
+    # retained for submit's dataset-failed-expectation-entry middleware
+    assert details["entities"] == [1, 2]
+
+
+def test_count_lpa_boundary_marks_a_failed_geometry_fetch_as_an_error(
+    dataset_path, mocker
+):
+    """a check that could not run must be distinguishable from a real finding without
+    string-matching the message"""
+    mocker.patch(
+        "requests.get",
+        side_effect=requests.exceptions.RequestException("404 Client Error"),
+    )
+
+    with spatialite.connect(dataset_path) as conn:
+        passed, message, details = count_lpa_boundary(conn, lpa="test", expected=0)
+
+    assert not passed
+    assert "error" in details
+    assert "404 Client Error" in details["error"]
+    assert "failures" not in details
+
+
+def test_count_deleted_entities_failures_carry_organisation_as_a_string(
+    dataset_path, mocker
+):
+    """one aggregated record rather than one per entity, since the check is already scoped
+    to a single organisation and the entity list can be very large. config renders
+    organisation_entity as a number, but every other check emits it as a string - a mixed
+    type would silently drop rows in the downstream join"""
+    organisation_entity = 109
+    test_entity_data = pd.DataFrame.from_dict(
+        {
+            "entity": ["1001", "1002"],
+            "name": ["test1", "test2"],
+            "organisation_entity": [109, 109],
+            "reference": ["ref1", "ref2"],
+        }
+    )
+    test_fact_resource_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["036d2b946bd41", "16bf38800aafd"],
+            "resource": ["2f7d900dd48fd02", "2f7d900dd48fd02"],
+            "entry_number": ["1", "1"],
+        }
+    )
+    test_fact_data = pd.DataFrame.from_dict(
+        {
+            "fact": ["036d2b946bd41", "16bf38800aafd"],
+            "entity": ["1001", "1001"],
+            "field": ["name", "reference"],
+            "value": ["abc", "ref1"],
+        }
+    )
+    mock_read_csv = mocker.patch("pandas.read_csv")
+
+    with spatialite.connect(dataset_path) as conn:
+        test_entity_data.to_sql("entity", conn, if_exists="replace", index=False)
+        test_fact_resource_data.to_sql(
+            "fact_resource", conn, if_exists="replace", index=False
+        )
+        test_fact_data.to_sql("fact", conn, if_exists="replace", index=False)
+        passed, _message, details = count_deleted_entities(
+            conn,
+            expected=0,
+            organisation_entity=organisation_entity,
+            resources_cache={109: ["2f7d900dd48fd02"]},
+        )
+
+    mock_read_csv.assert_not_called()
+    assert not passed
+    assert details["failures"] == [{"organisation_entity": "109", "count": 1}]
+    # retained for reporting-task/check_deleted_entities.py
+    assert details["entities"] == ["1002"]
+
+
+def test_duplicate_geometry_check_aggregates_failures_per_organisation(dataset_path):
+    """a cross-organisation pair counts for both sides, and an organisation with only
+    any_matches has nothing to act on so produces no failure record"""
+    rows = [
+        (1, "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", 100),
+        (2, "POLYGON((0 0, 0 2, 2 2, 2 0, 0 0))", 101),
+        (3, "POLYGON((0.5 0.5, 0.5 1.5, 1.5 1.5, 1.5 0.5, 0.5 0.5))", 102),
+        (4, "POLYGON((1 1, 1 3, 3 3, 3 1, 1 1))", 103),
+    ]
+    with spatialite.connect(dataset_path) as conn:
+        for entity, geometry, organisation_entity in rows:
+            conn.execute(
+                "INSERT INTO entity (entity, geometry, organisation_entity)"
+                " VALUES (?, ?, ?)",
+                (entity, geometry, organisation_entity),
+            )
+        conn.commit()
+        result, _message, details = duplicate_geometry_check(conn, "geometry")
+
+    assert not result
+    assert details["failures"] == [
+        {
+            "organisation_entity": "100",
+            "complete_matches": 1,
+            "single_matches": 1,
+            "any_matches": 1,
+            "count": 2,
+        },
+        {
+            "organisation_entity": "101",
+            "complete_matches": 1,
+            "single_matches": 1,
+            "any_matches": 1,
+            "count": 2,
+        },
+        {
+            "organisation_entity": "102",
+            "complete_matches": 0,
+            "single_matches": 2,
+            "any_matches": 1,
+            "count": 2,
+        },
+    ]
+    # 103 overlaps three entities but never by more than 95%, so it is not reported
+    assert "103" not in [f["organisation_entity"] for f in details["failures"]]
+    # retained for reporting-task/duplicate_geometry_expectations.py
+    assert len(details["complete_matches"]) == 1
+    assert len(details["single_matches"]) == 2
+    assert len(details["any_matches"]) == 3


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Updating the 3 dataset expectations so they now emit `details.failures[]`, with each element carrying an `organisation_entity`.

The change is **purely additive** — no key is renamed or removed, so the existing consumers in submit (`dataset-failed-expectation-entry.middleware.js`, `common.middleware.js`) and reporting-task (`duplicate_geometry_expectations.py`, `check_deleted_entities.py`) are unaffected.

## Why

Groundwork for the expectation → task PR I am going to do next (config#2912), which has to attribute every expectation failure to an organisation. Today only some checks carry one and each invents its own `details` shape, so the bridge would need a per-operation extractor. With a common `failures[]` it needs one code path, and new expectations need no bridge changes.

Two checks aggregate inside `failures[]` rather than emitting one record per entity, because the payloads are otherwise enormous: `duplicate_geometry_check` aggregates per organisation (277,620 match pairs across 10 datasets, ~30MB of JSON) and `count_deleted_entities` emits a single record per organisation (one production row has 780,636 entities). This aggregation exists **only inside the new `failures` key** — `entities`, `complete_matches`, `single_matches`, `any_matches`, `actual` and `expected` are all still emitted in full and unchanged, which is why the pre-existing tests asserting on them pass untouched. 


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2912)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

Ran all the checks locally using production data, produced expectations as expected.

### Why this is a safe change

The change is additive only — no key is renamed or removed, and the aggregation described above happens solely inside the new `failures` key. The four live consumers (`dataset-failed-expectation-entry.middleware.js` and `common.middleware.js` in submit, `duplicate_geometry_expectations.py` and `check_deleted_entities.py` in reporting-task) read `entities`, `complete_matches`, `single_matches`, `actual` and `expected`, all of which are emitted unchanged. The pre-existing tests already assert on those keys and pass without modification, which is the direct evidence rather than an argument.

Nothing yet reads `failures[]`, so merging this changes no downstream behaviour — it is inert until the expectation→task bridge lands. There is also no config change and therefore no merge-order constraint, unlike the earlier expectation work where an `expect.csv` row referencing a missing operation could fail a whole dataset build.

I have run these locally on the prod data and all looked good.


## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failure reports now include the relevant organisation for boundary, deletion and duplicate-geometry checks.
  * Geometry-fetch failures are clearly reported as errors.
  * Duplicate-geometry results are grouped and sorted by organisation and failure count.
  * Plan-field validation details now show actual and expected counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->