### PR TITLE
fix: entity priority - order on resource_start_date before entry_number

### DIFF
--- a/digital_land/package/dataset_parquet.py
+++ b/digital_land/package/dataset_parquet.py
@@ -600,15 +600,14 @@ class DatasetParquetPackage(Package):
             SELECT {fields_str}{optional_org_str}, priority FROM (
                 SELECT {fields_str},
                 MAX(priority) OVER (PARTITION BY entity) AS priority,
-                CASE WHEN resource_csv."end-date" IS NULL THEN '2999-12-31' ELSE resource_csv."end-date" END AS resource_end_date,
-                CASE WHEN resource_csv."start-date" IS NULL THEN '0001-01-01' ELSE resource_csv."start-date" END AS resource_start_date
+                CASE WHEN resource_csv."end-date" IS NULL THEN '2999-12-31' ELSE resource_csv."end-date" END AS resource_end_date
                 FROM parquet_scan('{transformed_parquet_dir}/{parquet_str}') tf
                 LEFT JOIN read_csv_auto('{resource_path}', max_line_size=40000000) resource_csv
                 ON tf.resource = resource_csv.resource
                 {entity_where_clause}
                 QUALIFY ROW_NUMBER() OVER (
                     PARTITION BY entity, field
-                    ORDER BY priority DESC, entry_date DESC, resource_end_date DESC, resource_start_date DESC, entry_number DESC, tf.resource, fact
+                    ORDER BY priority DESC, entry_date DESC, resource_end_date DESC, resource_csv."start-date" DESC, entry_number DESC, tf.resource, fact
                 ) = 1
             )
         """

--- a/digital_land/package/dataset_parquet.py
+++ b/digital_land/package/dataset_parquet.py
@@ -600,14 +600,15 @@ class DatasetParquetPackage(Package):
             SELECT {fields_str}{optional_org_str}, priority FROM (
                 SELECT {fields_str},
                 MAX(priority) OVER (PARTITION BY entity) AS priority,
-                CASE WHEN resource_csv."end-date" IS NULL THEN '2999-12-31' ELSE resource_csv."end-date" END AS resource_end_date
+                CASE WHEN resource_csv."end-date" IS NULL THEN '2999-12-31' ELSE resource_csv."end-date" END AS resource_end_date,
+                CASE WHEN resource_csv."start-date" IS NULL THEN '0001-01-01' ELSE resource_csv."start-date" END AS resource_start_date
                 FROM parquet_scan('{transformed_parquet_dir}/{parquet_str}') tf
                 LEFT JOIN read_csv_auto('{resource_path}', max_line_size=40000000) resource_csv
                 ON tf.resource = resource_csv.resource
                 {entity_where_clause}
                 QUALIFY ROW_NUMBER() OVER (
                     PARTITION BY entity, field
-                    ORDER BY priority DESC, entry_date DESC, entry_number DESC, resource_end_date DESC, tf.resource, fact
+                    ORDER BY priority DESC, entry_date DESC, resource_end_date DESC, resource_start_date DESC, entry_number DESC, tf.resource, fact
                 ) = 1
             )
         """

--- a/tests/acceptance/test_dataset_create.py
+++ b/tests/acceptance/test_dataset_create.py
@@ -254,7 +254,7 @@ def issue_dir(session_tmp_path):
 @pytest.fixture
 def resource_path(session_tmp_path):
     resource_path = session_tmp_path / "resource.csv"
-    columns = ["resource", "end-date"]
+    columns = ["resource", "start-date", "end-date"]
     with open(resource_path, "w") as f:
         f.write(",".join(columns) + "\n")
     return resource_path

--- a/tests/integration/package/test_dataset_parquet.py
+++ b/tests/integration/package/test_dataset_parquet.py
@@ -50,7 +50,7 @@ def org_path(tmp_path):
 @pytest.fixture
 def resource_path(tmp_path):
     resource_path = tmp_path / "resource.csv"
-    resource_columns = ["resource", "end-date"]
+    resource_columns = ["resource", "start-date", "end-date"]
     with open(resource_path, "w") as f:
         f.write(",".join(resource_columns) + "\n")
 
@@ -1178,3 +1178,184 @@ def test_deduplicate_buckets_creates_correct_files(tmp_path):
 
     df_01 = pd.read_parquet(result_paths[1])
     assert len(df_01) == 2, "bucket_01 has 2 distinct facts, both should be kept"
+
+
+# ---------------------------------------------------------------------------
+# Entity value selection: resource end-date vs entry-number ordering.
+#
+# The shared `resource_path` fixture above writes a header-only resource.csv, so
+# every resource left-joins to a NULL end-date and coalesces to the same
+# '2999-12-31' sentinel. That makes `resource_end_date` a constant across
+# candidate rows in those tests, so the criterion cannot discriminate and they
+# cannot tell the two orderings apart. These tests supply real resource rows.
+# ---------------------------------------------------------------------------
+
+# Two valid, distinct polygons. Compared via a marker coordinate rather than by
+# string equality because duckdb re-serialises the geometry type on output.
+STALE_GEOMETRY = "MULTIPOLYGON(((-1.135252 52.637731,-1.135319 52.637816,-1.135345 52.637806,-1.135252 52.637731)))"
+CURRENT_GEOMETRY = "MULTIPOLYGON(((-1.135252 52.637731,-1.135462 52.637966,-1.135723 52.637864,-1.135252 52.637731)))"
+
+
+def _which_geometry(value):
+    if "52.637864" in value:
+        return "current"
+    if "52.637806" in value:
+        return "stale"
+    return f"unrecognised geometry: {value}"
+
+
+@pytest.fixture
+def dated_resource_path(tmp_path):
+    """resource.csv carrying real end-dates, including one still-live resource."""
+    resource_path = tmp_path / "dated_resource.csv"
+    rows = [
+        # resource, start-date, end-date ("" end-date means still live)
+        ["res_ended_early", "2025-01-01", "2026-08-10"],
+        ["res_ended_late", "2025-06-01", "2026-08-12"],
+        ["res_live", "2026-01-01", ""],
+        ["res_live_newer", "2026-06-01", ""],
+    ]
+    with open(resource_path, "w") as f:
+        f.write("resource,start-date,end-date\n")
+        for row in rows:
+            f.write(",".join(row) + "\n")
+    return resource_path
+
+
+def _competing_geometry_rows(resources, entry_numbers, values):
+    """Two candidate geometry facts for one entity, tying on priority and entry_date."""
+    return {
+        "end_date": [np.nan] * 2,
+        "entity": [11, 11],
+        # Equal entry_date is the crux: in the reported case this is the listed
+        # building's own designation date, identical in both resources, so the
+        # tie falls straight through to the criteria under test.
+        "entry_date": ["1975-03-14"] * 2,
+        "entry_number": entry_numbers,
+        "fact": ["fact_a", "fact_b"],
+        "field": ["geometry"] * 2,
+        "reference_entity": [np.nan] * 2,
+        "resource": resources,
+        "start_date": [np.nan] * 2,
+        "value": values,
+        "priority": [2, 2],
+    }
+
+
+def _load_single_entity(data, tmp_path, org_path, resource_path):
+    """Run load_entities over one transformed frame and return the single entity row."""
+    transformed_parquet_dir = tmp_path / "transformed"
+    transformed_parquet_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame.from_dict(data).to_parquet(
+        transformed_parquet_dir / "transformed_resource.parquet", index=False
+    )
+
+    package = DatasetParquetPackage(
+        dataset="conservation-area",
+        path=tmp_path / "conservation-area",
+        specification_dir=None,
+    )
+    package.load_entities(transformed_parquet_dir, resource_path, org_path)
+
+    df = pd.read_parquet(
+        tmp_path
+        / "conservation-area"
+        / "entity"
+        / "dataset=conservation-area"
+        / "entity.parquet"
+    )
+    assert len(df) == 1, f"Expected exactly one entity, got {len(df)}"
+    return df.iloc[0]
+
+
+def test_load_entities_prefers_later_resource_over_higher_entry_number(
+    tmp_path, org_path, dated_resource_path
+):
+    """A later-ended resource wins even when its row has the lower entry_number.
+
+    Reproduces config#2945: a Leicester listed-building-outline entity kept
+    publishing its April 2025 geometry because `entry_number` was ranked above
+    `resource_end_date`, letting row position within a file decide the value
+    instead of which resource was more recent.
+    """
+    data = _competing_geometry_rows(
+        resources=["res_ended_early", "res_ended_late"],
+        entry_numbers=[99, 1],
+        values=[STALE_GEOMETRY, CURRENT_GEOMETRY],
+    )
+
+    entity = _load_single_entity(data, tmp_path, org_path, dated_resource_path)
+
+    assert _which_geometry(entity["geometry"]) == "current", (
+        "Expected the value from the resource with the later end-date, but got the "
+        "earlier resource's value -- entry_number is outranking resource end-date"
+    )
+
+
+def test_load_entities_prefers_live_resource_over_ended_resource(
+    tmp_path, org_path, dated_resource_path
+):
+    """A live resource (no end-date) beats an end-dated one.
+
+    This is the production shape of config#2945: the current Leicester resource
+    carries no end-date and so coalesces to the '2999-12-31' sentinel. Every
+    other test in this file leaves end-date NULL for all resources, so that
+    branch never actually decides anything there.
+    """
+    data = _competing_geometry_rows(
+        resources=["res_ended_late", "res_live"],
+        entry_numbers=[99, 1],
+        values=[STALE_GEOMETRY, CURRENT_GEOMETRY],
+    )
+
+    entity = _load_single_entity(data, tmp_path, org_path, dated_resource_path)
+
+    assert (
+        _which_geometry(entity["geometry"]) == "current"
+    ), "Expected the live resource's value to beat the end-dated resource's value"
+
+
+def test_load_entities_breaks_ties_on_entry_number_within_one_resource(
+    tmp_path, org_path, dated_resource_path
+):
+    """Within a single resource the higher entry_number still wins.
+
+    Guards the tie-breaker itself: with `resource_end_date` equal, `entry_number`
+    is the only remaining criterion that can discriminate, so dropping it from
+    the ORDER BY must not pass silently.
+    """
+    data = _competing_geometry_rows(
+        resources=["res_ended_late", "res_ended_late"],
+        entry_numbers=[1, 99],
+        values=[STALE_GEOMETRY, CURRENT_GEOMETRY],
+    )
+
+    entity = _load_single_entity(data, tmp_path, org_path, dated_resource_path)
+
+    assert (
+        _which_geometry(entity["geometry"]) == "current"
+    ), "Within one resource the row with the higher entry_number should win"
+
+
+def test_load_entities_prefers_later_starting_live_resource(
+    tmp_path, org_path, dated_resource_path
+):
+    """Between two live resources, the one that started later wins.
+
+    `resource_end_date` cannot separate live resources -- they both coalesce to
+    the '2999-12-31' sentinel -- so without `resource_start_date` the decision
+    falls back to `entry_number`. Measured on production data, this is the case
+    start-date uniquely resolves (config#2945 criterion 3).
+    """
+    data = _competing_geometry_rows(
+        resources=["res_live", "res_live_newer"],
+        entry_numbers=[99, 1],
+        values=[STALE_GEOMETRY, CURRENT_GEOMETRY],
+    )
+
+    entity = _load_single_entity(data, tmp_path, org_path, dated_resource_path)
+
+    assert _which_geometry(entity["geometry"]) == "current", (
+        "Both resources are live so end-date ties; expected the later-starting "
+        "resource to win, but entry_number decided it"
+    )


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Reorders the entity value-selection `ORDER BY` in `digital_land/package/dataset_parquet.py` so resource recency outranks row position.

```sql
-- before
ORDER BY priority DESC, entry_date DESC, entry_number DESC, resource_end_date DESC, tf.resource, fact
-- after
ORDER BY priority DESC, entry_date DESC, resource_end_date DESC, resource_start_date DESC, entry_number DESC, tf.resource, fact
```

`entry_number` becomes the final tie-breaker it was always meant to be. Adds four integration tests, one pinned to each criterion, and a `start-date` column to the resource fixtures.

## Why

config#2945 (DLSD-3458): a Leicester listed-building-outline entity continued publishing its April 2025 geometry after the authority corrected it in August 2026. Both values are present in the fact table and both carry the same `entry_date` — the listed building's own 1975 designation date rather than a collection date — so the tie fell straight through to `entry_number`, letting row position within a file decide the published value instead of which resource was more recent.

Both resource dates are needed. `resource_end_date` coalesces a live resource to `2999-12-31`, so it correctly ranks live resources above superseded ones and orders the rest by recency — but it cannot separate two live resources, which all land on that same `2999-12-31`. `resource_start_date` breaks those, and is what the ticket's third criterion asks for: measured across eight collections it uniquely resolves 1,260 of the 5,261 value changes.

The existing tests could not have caught any of this. So I have added some new tests to catch this going forwards.



## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2945)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

I have both new and old version of the code locally but with the published `fact`/`fact_resource` tables and `collection/resource.csv` for eight collections (54,148 entities): infrastructure-project, green-belt, special-area-of-conservation, agricultural-land-classification, local-plan, article-4-direction, conservation-area and brownfield-land. 5,261 values change and **every one moves from a superseded resource to a more recent one** — no case anywhere selects an older resource.

The only user-visible consequence is in brownfield-land: **170 sites across 28 LPAs gain an end-date and leave the active register**, and 5 move the other way and become active again. 151 of the 170 take their new end-date from the authority's currently live resource, so this corrects sites the old ordering was holding open against the LPA's own published data. No other collection tested produces an active-to-ended transition.

Adding `resource_start_date` accounts for 1,260 of the 5,261 changes — cases where competing values all come from currently live resources, so `resource_end_date` ties at the sentinel and the decision previously fell back to `entry_number`.


### Tested in DEV

I have pushed this change to DEV and run article-4-direction - all tasks ran green.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entity value selection so active and later-ending resources take precedence over earlier-ended resources.
  * When multiple active resources are available, the later-starting resource is selected.
  * Preserved entry-number ordering when records belong to the same resource.

* **Tests**
  * Added regression coverage for resource date precedence and entry-number tie-breaking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->