### PR TITLE
fix: prevent tests breaking on fact_resrouce col change

### DIFF
--- a/tests/integration/package/test_dataset_parquet.py
+++ b/tests/integration/package/test_dataset_parquet.py
@@ -397,7 +397,13 @@ def test_load_facts_single_file(data: dict, expected: int, tmp_path):
     assert (
         len(df) == expected
     ), "No. of facts does not match expected"  # No of unique facts
-    assert df.shape[1] == 9, "Not all columns saved in fact.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact.parquet columns do not match the specification"
 
 
 @pytest.mark.parametrize(
@@ -442,7 +448,13 @@ def test_load_facts_multiple_files(data1, data2, expected, tmp_path):
     assert (
         len(df) == expected
     ), "No. of facts does not match expected"  # No of unique facts
-    assert df.shape[1] == 9, "Not all columns saved in fact.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact.parquet columns do not match the specification"
 
 
 @pytest.mark.parametrize("data,expected", [(transformed_1_data, 16)])
@@ -497,7 +509,13 @@ def test_load_facts_one_file_with_empty_file(data, expected, tmp_path):
     assert (
         len(df) == expected
     ), "No. of facts does not match expected"  # No of unique facts
-    assert df.shape[1] == 9, "Not all columns saved in fact.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact.parquet columns do not match the specification"
 
 
 @pytest.mark.parametrize(
@@ -581,7 +599,13 @@ def test_load_functions_batch(
     assert (
         len(df) == expected_facts
     ), "No. of facts does not match expected"  # No of unique facts
-    assert df.shape[1] == 9, "Not all columns saved in fact.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact.parquet columns do not match the specification"
 
     # test fact_resource
     output_file = (
@@ -598,7 +622,13 @@ def test_load_functions_batch(
     assert len(df) > 0, "No data in fact-resource,parquet file"
     assert len(df) == expected_facts, "Not all data saved in fact-resource.parquet file"
 
-    assert df.shape[1] == 7, "Not all columns saved in fact-resource.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact-resource"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact-resource.parquet columns do not match the specification"
 
     # test entities
     output_file = (
@@ -648,7 +678,13 @@ def test_load_fact_resource_single_file(data, expected, tmp_path):
     assert len(df) > 0, "No data in fact-resource,parquet file"
     assert len(df) == expected, "Not all data saved in fact-resource.parquet file"
 
-    assert df.shape[1] == 7, "Not all columns saved in fact-resource.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact-resource"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact-resource.parquet columns do not match the specification"
 
 
 @pytest.mark.parametrize(
@@ -689,7 +725,13 @@ def test_load_fact_resource_two_filea(data_1, data_2, expected, tmp_path):
     assert len(df) > 0, "No data in fact-resource,parquet file"
     assert len(df) == expected, "Not all data saved in fact-resource.parquet file"
 
-    assert df.shape[1] == 7, "Not all columns saved in fact-resource.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact-resource"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact-resource.parquet columns do not match the specification"
 
 
 @pytest.mark.parametrize("data,expected", [(transformed_1_data, 16)])
@@ -742,7 +784,13 @@ def test_load_fact_resource_empty_file_with_another(data, expected, tmp_path):
     assert len(df) > 0, "No data in fact-resource,parquet file"
     assert len(df) == expected, "Not all data saved in fact-resource.parquet file"
 
-    assert df.shape[1] == 7, "Not all columns saved in fact-resource.parquet file"
+    expected_columns = [
+        field.replace("-", "_")
+        for field in package.specification.schema["fact-resource"]["fields"]
+    ]
+    assert (
+        list(df.columns) == expected_columns
+    ), "fact-resource.parquet columns do not match the specification"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/package/test_dataset_parquet.py
+++ b/tests/integration/package/test_dataset_parquet.py
@@ -7,9 +7,11 @@ import os
 import json
 import pyarrow.parquet as pq
 import pyarrow as pa
-from digital_land.package.dataset_parquet import DatasetParquetPackage
 import random
 import string
+
+from digital_land.package.dataset_parquet import DatasetParquetPackage
+from digital_land.specification import Specification
 
 
 class MockOrganisation(object):
@@ -293,6 +295,14 @@ transformed_2_data = {
 }
 
 
+def fact_resource_fields():
+    """fact-resource field names, underscored, in specification order."""
+    return [
+        field.replace("-", "_")
+        for field in Specification().schema["fact-resource"]["fields"]
+    ]
+
+
 @pytest.fixture
 def dataset_sqlite_path(tmp_path):
     """
@@ -337,16 +347,17 @@ def dataset_sqlite_path(tmp_path):
             );
     """
     )
+    # Built from the specification rather than hardcoded, so this fixture tracks
+    # fact-resource gaining or losing fields without needing an edit here.
+    integer_fields = {"entry_number", "priority", "entity"}
+    fact_resource_columns = ",\n            ".join(
+        f"{name} {'INTEGER' if name in integer_fields else 'TEXT'}"
+        for name in fact_resource_fields()
+    )
     conn.execute(
-        """
+        f"""
         CREATE TABLE fact_resource(
-            end_date TEXT,
-            fact TEXT,
-            entry_date TEXT,
-            entry_number INTEGER,
-            priority INTEGER,
-            resource TEXT,
-            start_date TEXT,
+            {fact_resource_columns},
             FOREIGN KEY(fact) REFERENCES fact(fact)
         );
     """
@@ -914,6 +925,8 @@ def test_load_entities_single_file(
                 "priority": [1],
                 "resource": [""],
                 "start_date": [1],
+                "entity": [1],
+                "field": [""],
             },
             {
                 "entity": [1],
@@ -945,7 +958,9 @@ def test_load_pq_to_sqlite_basic(
     )
     # write data to parquet files in the dataset path
     fact_df = pd.DataFrame.from_dict(fact_data)
-    fact_resource_df = pd.DataFrame.from_dict(fact_resource_data)
+    fact_resource_df = pd.DataFrame.from_dict(fact_resource_data)[
+        fact_resource_fields()
+    ]
     entity_df = pd.DataFrame.from_dict(entity_data)
 
     (dataset_parquet_path / "fact" / "dataset=conservation-area").mkdir(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Replaces the hardcoded column-count assertions in `test_dataset_parquet.py` with assertions that derive the expected columns from the specification, and checks column names and order rather than just the count.

## Why

Tests checking the table shape in specification repo should be in the specification repo not the digital-land-python repo

These tests hardcoded `fact.parquet` as 9 columns and `fact-resource.parquet` as 7. The specification is fetched from the specification repo's `main` branch at build time, so adding `entity` and `field` to `fact-resource` would have broken CI here the moment that change merged, and removing those fields from `fact` later would break it again. Deriving the expectation from the spec removes that coupling, and asserting on names and order is strictly stronger than a count — it catches a renamed or reordered column, which matters because the sqlite insert in `dataset_parquet.py` is positional.


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2960)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

This is just an edit to tests to tests passing is enough.

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

* Updated integration checks to validate exported Parquet columns against the package schema rather than fixed column counts.
* Improved coverage for fact and fact-resource outputs, including schema-defined fields and field ordering.
* Expanded SQLite test fixtures to include entity and field data, with support for dynamically generated fact-resource columns.
* Continued coverage for single-file, multi-file, batch, and empty-file scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->