### PR TITLE
fix: adding 2 new fields to some test data

### DIFF
--- a/tests/integration/package/test_dataset.py
+++ b/tests/integration/package/test_dataset.py
@@ -565,6 +565,8 @@ def test_insert_newest_date(
             "priority": None,
             "resource": "",
             "start_date": "",
+            "entity": 44006677,
+            "field": "name",
         },
         {
             "end_date": "",
@@ -574,6 +576,8 @@ def test_insert_newest_date(
             "priority": None,
             "resource": "",
             "start_date": "",
+            "entity": 44006677,
+            "field": "name",
         },
     ]
 
@@ -609,6 +613,8 @@ def test_insert_newest_date(
             "priority": None,
             "resource": "",
             "start_date": "",
+            "entity": 44006677,
+            "field": "name",
         },
         {
             "end_date": "",
@@ -618,6 +624,8 @@ def test_insert_newest_date(
             "priority": None,
             "resource": "",
             "start_date": "",
+            "entity": 44006677,
+            "field": "name",
         },
     ]
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds `entity` and `field` to the four expected `fact_resource` rows in `test_insert_newest_date`.

## Why

That test does `SELECT * FROM fact_resource` and compares against hardcoded dicts, so it started failing when specification#213 added those two fields to `fact-resource`. This is the last DLP breakage from that change.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2960)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: This is just about fixing some existing tests.
- [ ] I need help with writing tests

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test expectations to include entity and field details returned by insert queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->